### PR TITLE
Rerender single functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ dist
 
 .coverage
 logging_config.yaml
+
+.claude/worktrees/

--- a/codeplain_REST_api.py
+++ b/codeplain_REST_api.py
@@ -180,6 +180,8 @@ class CodeplainAPI:
         required_modules: dict,
         include_unittests: bool,
         run_state: RunState,
+        is_reimplementation: bool = False,
+        old_functional_requirement_text: Optional[str] = None,
     ) -> dict[str, str]:
         """
         Renders the content of a functionality based on the provided ID,
@@ -219,7 +221,11 @@ class CodeplainAPI:
             "module_name": module_name,
             "required_modules": required_modules,
             "include_unittests": include_unittests,
+            "is_reimplementation": is_reimplementation,
         }
+
+        if old_functional_requirement_text is not None:
+            payload["old_functional_requirement_text"] = old_functional_requirement_text
 
         return self.post_request(endpoint_url, headers, payload, run_state)
 
@@ -317,6 +323,7 @@ class CodeplainAPI:
         conformance_tests_json,
         all_acceptance_tests,
         run_state: RunState,
+        is_reimplementation: bool = False,
     ):
         endpoint_url = f"{self.api_url}/render_conformance_tests"
         headers = {"X-API-Key": self.api_key, "Content-Type": "application/json"}
@@ -333,6 +340,7 @@ class CodeplainAPI:
             "conformance_tests_folder_name": conformance_tests_folder_name,
             "conformance_tests_json": conformance_tests_json,
             "all_acceptance_tests": all_acceptance_tests,
+            "is_reimplementation": is_reimplementation,
         }
 
         response = self.post_request(endpoint_url, headers, payload, run_state)

--- a/codeplain_REST_api.py
+++ b/codeplain_REST_api.py
@@ -184,6 +184,8 @@ class CodeplainAPI:
         required_modules: dict,
         include_unittests: bool,
         run_state: RunState,
+        is_reimplementation: bool = False,
+        old_functional_requirement_text: Optional[str] = None,
     ) -> dict[str, str]:
         """
         Renders the content of a functionality based on the provided ID,
@@ -223,7 +225,11 @@ class CodeplainAPI:
             "module_name": module_name,
             "required_modules": required_modules,
             "include_unittests": include_unittests,
+            "is_reimplementation": is_reimplementation,
         }
+
+        if old_functional_requirement_text is not None:
+            payload["old_functional_requirement_text"] = old_functional_requirement_text
 
         return self.post_request(endpoint_url, headers, payload, run_state)
 
@@ -321,6 +327,7 @@ class CodeplainAPI:
         conformance_tests_json,
         all_acceptance_tests,
         run_state: RunState,
+        is_reimplementation: bool = False,
     ):
         endpoint_url = f"{self.api_url}/render_conformance_tests"
         headers = {"X-API-Key": self.api_key, "Content-Type": "application/json"}
@@ -337,6 +344,7 @@ class CodeplainAPI:
             "conformance_tests_folder_name": conformance_tests_folder_name,
             "conformance_tests_json": conformance_tests_json,
             "all_acceptance_tests": all_acceptance_tests,
+            "is_reimplementation": is_reimplementation,
         }
 
         response = self.post_request(endpoint_url, headers, payload, run_state)

--- a/codeplain_REST_api.py
+++ b/codeplain_REST_api.py
@@ -186,6 +186,7 @@ class CodeplainAPI:
         run_state: RunState,
         is_reimplementation: bool = False,
         old_functional_requirement_text: Optional[str] = None,
+        code_functional_requirements: Optional[list] = None,
     ) -> dict[str, str]:
         """
         Renders the content of a functionality based on the provided ID,
@@ -230,6 +231,9 @@ class CodeplainAPI:
 
         if old_functional_requirement_text is not None:
             payload["old_functional_requirement_text"] = old_functional_requirement_text
+
+        if code_functional_requirements is not None:
+            payload["code_functional_requirements"] = code_functional_requirements
 
         return self.post_request(endpoint_url, headers, payload, run_state)
 

--- a/git_utils.py
+++ b/git_utils.py
@@ -17,6 +17,7 @@ CONFORMANCE_TESTS_PASSED_COMMIT_MESSAGE = (
 # Following messages are used as checkpoints in the git history
 # Changing them will break backwards compatibility so change them with care
 FUNCTIONAL_REQUIREMENT_FINISHED_COMMIT_MESSAGE = "[Codeplain] functionality ID (FRID):{} fully implemented"
+FUNCTIONAL_REQUIREMENT_REIMPLEMENTED_COMMIT_MESSAGE = "[Codeplain] functionality ID (FRID):{} fully reimplemented"
 INITIAL_COMMIT_MESSAGE = "[Codeplain] Initial module commit"
 BASE_FOLDER_COMMIT_MESSAGE = "[Codeplain] Initialize build with Base Folder content"
 
@@ -440,9 +441,23 @@ def get_last_rendered_functionality(repo_path: Union[str, os.PathLike]) -> tuple
         return None, None
 
     repo = Repo(repo_path)
-    grep_pattern = FUNCTIONAL_REQUIREMENT_FINISHED_COMMIT_MESSAGE.format(".*")
-    grep_pattern = grep_pattern.replace("[", "\\[").replace("]", "\\]")
-    commit_sha = repo.git.rev_list(repo.active_branch.name, "--grep", grep_pattern, "-n", "1")
+
+    implemented_pattern = FUNCTIONAL_REQUIREMENT_FINISHED_COMMIT_MESSAGE.format(".*")
+    implemented_pattern = implemented_pattern.replace("[", "\\[").replace("]", "\\]")
+    implemented_sha = repo.git.rev_list(repo.active_branch.name, "--grep", implemented_pattern, "-n", "1")
+
+    reimplemented_pattern = FUNCTIONAL_REQUIREMENT_REIMPLEMENTED_COMMIT_MESSAGE.format(".*")
+    reimplemented_pattern = reimplemented_pattern.replace("[", "\\[").replace("]", "\\]")
+    reimplemented_sha = repo.git.rev_list(repo.active_branch.name, "--grep", reimplemented_pattern, "-n", "1")
+
+    # Pick the more recent of the two (rev-list outputs most-recent first)
+    if implemented_sha and reimplemented_sha:
+        all_shas = repo.git.rev_list(repo.active_branch.name).splitlines()
+        implemented_idx = all_shas.index(implemented_sha)
+        reimplemented_idx = all_shas.index(reimplemented_sha)
+        commit_sha = implemented_sha if implemented_idx < reimplemented_idx else reimplemented_sha
+    else:
+        commit_sha = implemented_sha or reimplemented_sha
 
     if not commit_sha:
         # Repo was interrupted during the first functionality, fallback to initial commit and provide only module name
@@ -469,7 +484,7 @@ def get_last_rendered_functionality(repo_path: Union[str, os.PathLike]) -> tuple
     if isinstance(commit_message, bytes):
         commit_message = commit_message.decode("utf-8")
 
-    match = re.search(r"FRID\):(\S+) fully implemented", commit_message)
+    match = re.search(r"FRID\):(\S+) fully (?:re)?implemented", commit_message)
     if not match:
         raise InvalidGitRepositoryError(
             "Git repository is in an invalid state. Could not find frid in finished commit."

--- a/git_utils.py
+++ b/git_utils.py
@@ -17,6 +17,7 @@ CONFORMANCE_TESTS_PASSED_COMMIT_MESSAGE = (
 # Following messages are used as checkpoints in the git history
 # Changing them will break backwards compatibility so change them with care
 FUNCTIONAL_REQUIREMENT_FINISHED_COMMIT_MESSAGE = "[Codeplain] functionality ID (FRID):{} fully implemented"
+FUNCTIONAL_REQUIREMENT_REIMPLEMENTED_COMMIT_MESSAGE = "[Codeplain] functionality ID (FRID):{} fully reimplemented"
 INITIAL_COMMIT_MESSAGE = "[Codeplain] Initial module commit"
 BASE_FOLDER_COMMIT_MESSAGE = "[Codeplain] Initialize build with Base Folder content"
 
@@ -430,9 +431,23 @@ def get_last_rendered_functionality(repo_path: Union[str, os.PathLike]) -> tuple
         return None, None
 
     repo = Repo(repo_path)
-    grep_pattern = FUNCTIONAL_REQUIREMENT_FINISHED_COMMIT_MESSAGE.format(".*")
-    grep_pattern = grep_pattern.replace("[", "\\[").replace("]", "\\]")
-    commit_sha = repo.git.rev_list(repo.active_branch.name, "--grep", grep_pattern, "-n", "1")
+
+    implemented_pattern = FUNCTIONAL_REQUIREMENT_FINISHED_COMMIT_MESSAGE.format(".*")
+    implemented_pattern = implemented_pattern.replace("[", "\\[").replace("]", "\\]")
+    implemented_sha = repo.git.rev_list(repo.active_branch.name, "--grep", implemented_pattern, "-n", "1")
+
+    reimplemented_pattern = FUNCTIONAL_REQUIREMENT_REIMPLEMENTED_COMMIT_MESSAGE.format(".*")
+    reimplemented_pattern = reimplemented_pattern.replace("[", "\\[").replace("]", "\\]")
+    reimplemented_sha = repo.git.rev_list(repo.active_branch.name, "--grep", reimplemented_pattern, "-n", "1")
+
+    # Pick the more recent of the two (rev-list outputs most-recent first)
+    if implemented_sha and reimplemented_sha:
+        all_shas = repo.git.rev_list(repo.active_branch.name).splitlines()
+        implemented_idx = all_shas.index(implemented_sha)
+        reimplemented_idx = all_shas.index(reimplemented_sha)
+        commit_sha = implemented_sha if implemented_idx < reimplemented_idx else reimplemented_sha
+    else:
+        commit_sha = implemented_sha or reimplemented_sha
 
     if not commit_sha:
         # Repo was interrupted during the first functionality, fallback to initial commit and provide only module name
@@ -459,7 +474,7 @@ def get_last_rendered_functionality(repo_path: Union[str, os.PathLike]) -> tuple
     if isinstance(commit_message, bytes):
         commit_message = commit_message.decode("utf-8")
 
-    match = re.search(r"FRID\):(\S+) fully implemented", commit_message)
+    match = re.search(r"FRID\):(\S+) fully (?:re)?implemented", commit_message)
     if not match:
         raise InvalidGitRepositoryError(
             "Git repository is in an invalid state. Could not find frid in finished commit."

--- a/module_renderer.py
+++ b/module_renderer.py
@@ -27,6 +27,7 @@ class ModuleRenderer:
         event_bus: EventBus,
         stop_event: threading.Event | None = None,
         enter_pause_event: threading.Event | None = None,
+        is_rerender: bool = False,
     ):
         self.codeplainAPI = codeplainAPI
         self.plain_module = plain_module
@@ -37,6 +38,7 @@ class ModuleRenderer:
         self.event_bus = event_bus
         self.stop_event = stop_event
         self.enter_pause_event = enter_pause_event
+        self.is_rerender = is_rerender
 
     def _build_render_context_for_module(
         self,
@@ -65,6 +67,7 @@ class ModuleRenderer:
             test_script_timeout=self.args.test_script_timeout,
             stop_event=self.stop_event,
             enter_pause_event=self.enter_pause_event,
+            is_rerender=self.is_rerender,
         )
 
     def _render_module(

--- a/module_renderer.py
+++ b/module_renderer.py
@@ -26,6 +26,7 @@ class ModuleRenderer:
         event_bus: EventBus,
         stop_event: threading.Event | None = None,
         enter_pause_event: threading.Event | None = None,
+        is_rerender: bool = False,
     ):
         self.codeplainAPI = codeplainAPI
         self.plain_module = plain_module
@@ -36,6 +37,7 @@ class ModuleRenderer:
         self.event_bus = event_bus
         self.stop_event = stop_event
         self.enter_pause_event = enter_pause_event
+        self.is_rerender = is_rerender
 
     def _build_render_context_for_module(
         self,
@@ -63,6 +65,7 @@ class ModuleRenderer:
             test_script_timeout=self.args.test_script_timeout,
             stop_event=self.stop_event,
             enter_pause_event=self.enter_pause_event,
+            is_rerender=self.is_rerender,
         )
 
     def _render_module(

--- a/plain2code.py
+++ b/plain2code.py
@@ -139,12 +139,17 @@ def _check_connection(codeplainAPI: codeplain_api.CodeplainAPI):
 def render(args, run_state: RunState, event_bus: EventBus, default_log_level: str = "INFO"):  # noqa: C901
     template_dirs = file_utils.get_template_directories(args.filename, args.template_dir, DEFAULT_TEMPLATE_DIRS)
 
-    # Compute render range from either --render-range or --render-from
+    # Compute render range from either --render-range, --render-from, or --rerender
     render_range = None
-    if args.render_range or args.render_from:
+    is_rerender = False
+    if args.render_range or args.render_from or args.rerender:
         # Parse the plain file to get the plain_source for FRID extraction
         _, plain_source, _ = plain_file.plain_file_parser(args.filename, template_dirs)
-        render_range = plain_spec.compute_render_range(args, plain_source)
+        if args.rerender:
+            render_range = plain_spec.get_render_range(args.rerender + "," + args.rerender, plain_source)
+            is_rerender = True
+        else:
+            render_range = plain_spec.compute_render_range(args, plain_source)
 
     codeplainAPI = codeplain_api.CodeplainAPI(args.api_key, console)
     assert args.api is not None and args.api != "", "API URL is required"
@@ -164,7 +169,7 @@ def render(args, run_state: RunState, event_bus: EventBus, default_log_level: st
     )
 
     render_choice = None
-    if render_range is None:
+    if render_range is None and not is_rerender:
         plain_module_render_state = get_plain_module_render_state(plain_module)
         if plain_module_render_state is not None:
             render_choices = get_render_choices(plain_module, plain_module_render_state, args.force_render)
@@ -212,6 +217,7 @@ def render(args, run_state: RunState, event_bus: EventBus, default_log_level: st
         event_bus,
         stop_event=stop_event,
         enter_pause_event=enter_pause_event,
+        is_rerender=is_rerender,
     )
 
     render_error: list[Exception] = []

--- a/plain2code.py
+++ b/plain2code.py
@@ -197,10 +197,15 @@ def render(  # noqa: C901
     event_bus: EventBus,
     default_log_level: str = "INFO",
 ):
-    # Compute render range from either --render-range or --render-from
+    # Compute render range from either --render-range, --render-from, or --rerender
     render_range = None
-    if args.render_range or args.render_from:
-        render_range = plain_spec.compute_render_range(args, plain_module.plain_source)
+    is_rerender = False
+    if args.render_range or args.render_from or args.rerender:
+        if args.rerender:
+            render_range = plain_spec.get_render_range(args.rerender + "," + args.rerender, plain_module.plain_source)
+            is_rerender = True
+        else:
+            render_range = plain_spec.compute_render_range(args, plain_module.plain_source)
 
     codeplainAPI = codeplain_api.CodeplainAPI(args.api_key, console)
     assert args.api is not None and args.api != "", "API URL is required"
@@ -230,7 +235,7 @@ def render(  # noqa: C901
         module.reconcile_metadata_with_git()
 
     render_choice = None
-    if render_range is None:
+    if render_range is None and not is_rerender:
         plain_module_render_state = get_plain_module_render_state(plain_module, args.render_conformance_tests)
         if plain_module_render_state is not None:
             render_choices = get_render_choices(plain_module, plain_module_render_state, args.force_render)
@@ -278,6 +283,7 @@ def render(  # noqa: C901
         event_bus,
         stop_event=stop_event,
         enter_pause_event=enter_pause_event,
+        is_rerender=is_rerender,
     )
 
     render_error: list[Exception] = []

--- a/plain2code_arguments.py
+++ b/plain2code_arguments.py
@@ -226,6 +226,13 @@ def create_parser():
         help="Continue generation starting from this specific functionality (e.g. `2`). "
         "The functionality with this ID will be included in the output. The functionality ID must match one of the functionalities in your plain file.",
     )
+    render_range_group.add_argument(
+        "--rerender",
+        type=frid_string,
+        help="Re-render a single already-rendered functionality (e.g. `2`). "
+        "Adds a new commit on top of the current HEAD without reverting any prior work. "
+        "Only top-level integer FRIDs are supported.",
+    )
 
     parser.add_argument(
         "--force-render",

--- a/plain2code_arguments.py
+++ b/plain2code_arguments.py
@@ -230,7 +230,6 @@ def create_parser():
         "--rerender",
         type=frid_string,
         help="Re-render a single already-rendered functionality (e.g. `2`). "
-        "Adds a new commit on top of the current HEAD without reverting any prior work. "
         "Only top-level integer FRIDs are supported.",
     )
 

--- a/plain2code_arguments.py
+++ b/plain2code_arguments.py
@@ -289,7 +289,6 @@ def create_parser():
         "--rerender",
         type=frid_string,
         help="Re-render a single already-rendered functionality (e.g. `2`). "
-        "Adds a new commit on top of the current HEAD without reverting any prior work. "
         "Only top-level integer FRIDs are supported.",
     )
 

--- a/plain2code_arguments.py
+++ b/plain2code_arguments.py
@@ -285,6 +285,13 @@ def create_parser():
         help="Continue generation starting from this specific functionality (e.g. `2`). "
         "The functionality with this ID will be included in the output. The functionality ID must match one of the functionalities in your plain file.",
     )
+    render_range_group.add_argument(
+        "--rerender",
+        type=frid_string,
+        help="Re-render a single already-rendered functionality (e.g. `2`). "
+        "Adds a new commit on top of the current HEAD without reverting any prior work. "
+        "Only top-level integer FRIDs are supported.",
+    )
 
     _add_arg(
         parser,

--- a/plain_modules.py
+++ b/plain_modules.py
@@ -108,6 +108,21 @@ class PlainModule:
         with open(metadata_path, "r", encoding="utf-8") as f:
             return json.load(f)
 
+    def update_frid_in_module_metadata(self, frid: str, frid_text: str) -> None:
+        metadata = self.load_module_metadata() or {}
+        functionalities = metadata.get(MODULE_FUNCTIONALITIES, [])
+        frid_index = int(frid) - 1
+        if frid_index < len(functionalities):
+            functionalities[frid_index] = frid_text
+        else:
+            functionalities.append(frid_text)
+        metadata[MODULE_FUNCTIONALITIES] = functionalities
+
+        codeplain_folder = self.get_codeplain_folder()
+        os.makedirs(codeplain_folder, exist_ok=True)
+        with open(self.module_metadata_path(), "w", encoding="utf-8") as f:
+            json.dump(metadata, f, indent=4)
+
     def get_module_source_hash(self) -> str:
         return plain_spec.get_hash_value([self.plain_source] + self.resources_list)
 

--- a/plain_modules.py
+++ b/plain_modules.py
@@ -108,7 +108,7 @@ class PlainModule:
         with open(metadata_path, "r", encoding="utf-8") as f:
             return json.load(f)
 
-    def update_frid_in_module_metadata(self, frid: str, frid_text: str) -> None:
+    def update_frid_in_module_metadata(self, frid: str, frid_text: str, update_source_hash: bool = False) -> None:
         metadata = self.load_module_metadata() or {}
         functionalities = metadata.get(MODULE_FUNCTIONALITIES, [])
         frid_index = int(frid) - 1
@@ -117,6 +117,8 @@ class PlainModule:
         else:
             functionalities.append(frid_text)
         metadata[MODULE_FUNCTIONALITIES] = functionalities
+        if update_source_hash:
+            metadata["source_hash"] = self.get_module_source_hash()
 
         codeplain_folder = self.get_codeplain_folder()
         os.makedirs(codeplain_folder, exist_ok=True)

--- a/plain_modules.py
+++ b/plain_modules.py
@@ -307,7 +307,7 @@ class PlainModule:
     def load_module_metadata(self) -> dict | None:
         return metadata_utils.load_metadata(self.module_metadata_path())
 
-    def update_frid_in_module_metadata(self, frid: str) -> None:
+    def update_frid_in_module_metadata(self, frid: str, update_source_hash: bool = False) -> None:
         # Store the raw FR markdown (with any {{ code_variable }} placeholders intact), exactly
         # as save_module_metadata and the change-detection diff read it. Storing the rendered
         # text (code variables already substituted) would make the diff report a spurious edit
@@ -321,6 +321,8 @@ class PlainModule:
         else:
             functionalities.append(frid_text)
         metadata[MODULE_FUNCTIONALITIES] = functionalities
+        if update_source_hash:
+            metadata["source_hash"] = self.get_module_source_hash()
 
         metadata_utils.write_metadata(self.module_metadata_path(), metadata)
 

--- a/render_machine/actions/commit_conformance_tests_changes.py
+++ b/render_machine/actions/commit_conformance_tests_changes.py
@@ -10,9 +10,8 @@ class CommitConformanceTestsChanges(BaseAction):
     SUCCESSFUL_OUTCOME_IMPLEMENTATION_NOT_UPDATED = "conformance_tests_changes_committed_implementation_not_updated"
     SUCCESSFUL_OUTCOME_IMPLEMENTATION_UPDATED = "conformance_tests_changes_committed_implementation_updated"
 
-    def __init__(self, implementation_code_commit_message: str, conformance_tests_commit_message: str):
+    def __init__(self, implementation_code_commit_message: str):
         self.implementation_code_commit_message = implementation_code_commit_message
-        self.conformance_tests_commit_message = conformance_tests_commit_message
 
     def execute(self, render_context: RenderContext, _previous_action_payload: Any | None):
         implementation_updated = False
@@ -26,8 +25,13 @@ class CommitConformanceTestsChanges(BaseAction):
             )
             implementation_updated = True
 
+        conformance_tests_commit_message = (
+            git_utils.FUNCTIONAL_REQUIREMENT_REIMPLEMENTED_COMMIT_MESSAGE
+            if render_context.is_rerender
+            else git_utils.FUNCTIONAL_REQUIREMENT_FINISHED_COMMIT_MESSAGE
+        )
         functional_requirement_text = render_context.frid_context.specifications[plain_spec.FUNCTIONAL_REQUIREMENTS][-1]
-        templated_functional_requirement_finished_commit_msg = self.conformance_tests_commit_message.format(
+        templated_functional_requirement_finished_commit_msg = conformance_tests_commit_message.format(
             render_context.frid_context.frid
         )
         formatted_conformance_commit_msg = (

--- a/render_machine/actions/finish_functional_requirement.py
+++ b/render_machine/actions/finish_functional_requirement.py
@@ -12,6 +12,7 @@ class FinishFunctionalRequirement(BaseAction):
         render_context.plain_module.update_frid_in_module_metadata(
             render_context.frid_context.frid,
             render_context.frid_context.functional_requirement_text,
+            update_source_hash=render_context.is_rerender,
         )
 
         commit_message = (

--- a/render_machine/actions/finish_functional_requirement.py
+++ b/render_machine/actions/finish_functional_requirement.py
@@ -9,6 +9,11 @@ class FinishFunctionalRequirement(BaseAction):
     SUCCESSFUL_OUTCOME = "functional_requirement_finished"
 
     def execute(self, render_context: RenderContext, _previous_action_payload: Any | None):
+        render_context.plain_module.update_frid_in_module_metadata(
+            render_context.frid_context.frid,
+            render_context.frid_context.functional_requirement_text,
+        )
+
         commit_message = (
             git_utils.FUNCTIONAL_REQUIREMENT_REIMPLEMENTED_COMMIT_MESSAGE
             if render_context.is_rerender

--- a/render_machine/actions/finish_functional_requirement.py
+++ b/render_machine/actions/finish_functional_requirement.py
@@ -1,14 +1,26 @@
 from typing import Any
 
-from render_machine.actions.commit_implementation_code_changes import CommitImplementationCodeChanges
+import git_utils
+from render_machine.actions.base_action import BaseAction
 from render_machine.render_context import RenderContext
 
 
-class FinishFunctionalRequirement(CommitImplementationCodeChanges):
+class FinishFunctionalRequirement(BaseAction):
     SUCCESSFUL_OUTCOME = "functional_requirement_finished"
 
-    def execute(self, render_context: RenderContext, previous_action_payload: Any | None):
-        super().execute(render_context, previous_action_payload)
+    def execute(self, render_context: RenderContext, _previous_action_payload: Any | None):
+        commit_message = (
+            git_utils.FUNCTIONAL_REQUIREMENT_REIMPLEMENTED_COMMIT_MESSAGE
+            if render_context.is_rerender
+            else git_utils.FUNCTIONAL_REQUIREMENT_FINISHED_COMMIT_MESSAGE
+        )
+        git_utils.add_all_files_and_commit(
+            render_context.build_folder,
+            commit_message.format(render_context.frid_context.frid),
+            render_context.module_name,
+            render_context.frid_context.frid,
+            render_context.run_state.render_id,
+        )
 
         render_context.codeplain_api.finish_functional_requirement(
             render_context.frid_context.frid,

--- a/render_machine/actions/finish_functional_requirement.py
+++ b/render_machine/actions/finish_functional_requirement.py
@@ -1,16 +1,28 @@
 from typing import Any
 
-from render_machine.actions.commit_implementation_code_changes import CommitImplementationCodeChanges
+import git_utils
+from render_machine.actions.base_action import BaseAction
 from render_machine.render_context import RenderContext
 
 
-class FinishFunctionalRequirement(CommitImplementationCodeChanges):
+class FinishFunctionalRequirement(BaseAction):
     SUCCESSFUL_OUTCOME = "functional_requirement_finished"
 
-    def execute(self, render_context: RenderContext, previous_action_payload: Any | None):
+    def execute(self, render_context: RenderContext, _previous_action_payload: Any | None):
         render_context.plain_module.update_frid_in_module_metadata(render_context.frid_context.frid)
 
-        super().execute(render_context, previous_action_payload)
+        commit_message = (
+            git_utils.FUNCTIONAL_REQUIREMENT_REIMPLEMENTED_COMMIT_MESSAGE
+            if render_context.is_rerender
+            else git_utils.FUNCTIONAL_REQUIREMENT_FINISHED_COMMIT_MESSAGE
+        )
+        git_utils.add_all_files_and_commit(
+            render_context.build_folder,
+            commit_message.format(render_context.frid_context.frid),
+            render_context.module_name,
+            render_context.frid_context.frid,
+            render_context.run_state.render_id,
+        )
 
         render_context.codeplain_api.finish_functional_requirement(
             render_context.frid_context.frid,

--- a/render_machine/actions/finish_functional_requirement.py
+++ b/render_machine/actions/finish_functional_requirement.py
@@ -9,7 +9,10 @@ class FinishFunctionalRequirement(BaseAction):
     SUCCESSFUL_OUTCOME = "functional_requirement_finished"
 
     def execute(self, render_context: RenderContext, _previous_action_payload: Any | None):
-        render_context.plain_module.update_frid_in_module_metadata(render_context.frid_context.frid)
+        render_context.plain_module.update_frid_in_module_metadata(
+            render_context.frid_context.frid,
+            update_source_hash=render_context.is_rerender,
+        )
 
         commit_message = (
             git_utils.FUNCTIONAL_REQUIREMENT_REIMPLEMENTED_COMMIT_MESSAGE

--- a/render_machine/actions/prepare_repositories.py
+++ b/render_machine/actions/prepare_repositories.py
@@ -106,8 +106,7 @@ class PrepareRepositories(BaseAction):
         module_metadata = render_context.plain_module.load_module_metadata()
         if not module_metadata or "functionalities" not in module_metadata:
             render_context.dispatch_error(
-                "module_metadata.json is missing or incomplete. "
-                "Please re-render the module from the beginning."
+                "module_metadata.json is missing or incomplete. " "Please re-render the module from the beginning."
             )
             return "error", None
 

--- a/render_machine/actions/prepare_repositories.py
+++ b/render_machine/actions/prepare_repositories.py
@@ -13,6 +13,9 @@ class PrepareRepositories(BaseAction):
     SUCCESSFUL_OUTCOME = "repositories_prepared"
 
     def execute(self, render_context: RenderContext, _previous_action_payload: Any | None):
+        if render_context.is_rerender:
+            return self._prepare_rerender(render_context)
+
         if render_context.render_range is not None and render_context.render_range[0] != plain_spec.get_first_frid(
             render_context.plain_source_tree
         ):
@@ -76,6 +79,50 @@ class PrepareRepositories(BaseAction):
                     render_context.module_name,
                     render_context.run_state.render_id,
                     initial_files,
+                )
+
+        return self.SUCCESSFUL_OUTCOME, None
+
+    def _prepare_rerender(self, render_context: RenderContext):
+        frid = render_context.render_range[0]
+
+        if "." in frid:
+            render_context.dispatch_error(
+                f"--rerender only supports top-level integer FRIDs (e.g. `1`, `2`). "
+                f"Nested FRID `{frid}` is not supported."
+            )
+            return "error", None
+
+        if not git_utils.has_commit_for_frid(render_context.build_folder, frid, render_context.module_name):
+            render_context.dispatch_error(
+                f"Cannot re-render functionality {frid} because it has not been fully rendered yet. "
+                f"Please render all functionalities first by running: "
+                f"codeplain {render_context.module_name}.plain"
+            )
+            return "error", None
+
+        render_context.starting_frid = frid
+
+        module_metadata = render_context.plain_module.load_module_metadata()
+        if not module_metadata or "functionalities" not in module_metadata:
+            render_context.dispatch_error(
+                "module_metadata.json is missing or incomplete. "
+                "Please re-render the module from the beginning."
+            )
+            return "error", None
+
+        render_context.old_frid_spec = module_metadata["functionalities"][int(frid) - 1]
+
+        if render_context.render_conformance_tests:
+            conformance_tests_json = render_context.conformance_tests.get_conformance_tests_json(
+                render_context.module_name
+            )
+            if frid in conformance_tests_json:
+                old_folder = conformance_tests_json[frid]["folder_name"]
+                file_utils.delete_folder(old_folder)
+                del conformance_tests_json[frid]
+                render_context.conformance_tests.dump_conformance_tests_json(
+                    render_context.module_name, conformance_tests_json
                 )
 
         return self.SUCCESSFUL_OUTCOME, None

--- a/render_machine/actions/prepare_repositories.py
+++ b/render_machine/actions/prepare_repositories.py
@@ -109,6 +109,10 @@ class PrepareRepositories(BaseAction):
             return "error", None
 
         render_context.old_frid_spec = module_metadata["functionalities"][int(frid) - 1]
+        # The specs the code on disk currently implements (code-truth). Sent to the API so the
+        # reimplementation prompt shows the old spec for any changed-but-not-yet-rerendered FR,
+        # keeping specs and code in sync.
+        render_context.code_functional_requirements = module_metadata["functionalities"]
 
         if render_context.render_conformance_tests:
             conformance_tests_json = render_context.conformance_tests.get_conformance_tests_json(

--- a/render_machine/actions/prepare_repositories.py
+++ b/render_machine/actions/prepare_repositories.py
@@ -12,6 +12,9 @@ class PrepareRepositories(BaseAction):
     SUCCESSFUL_OUTCOME = "repositories_prepared"
 
     def execute(self, render_context: RenderContext, _previous_action_payload: Any | None):
+        if render_context.is_rerender:
+            return self._prepare_rerender(render_context)
+
         if render_context.render_range is not None and render_context.render_range[0] != plain_spec.get_first_frid(
             render_context.plain_source_tree
         ):
@@ -74,6 +77,50 @@ class PrepareRepositories(BaseAction):
                     render_context.conformance_tests.get_module_conformance_tests_folder(render_context.module_name),
                     render_context.module_name,
                     render_context.run_state.render_id,
+                )
+
+        return self.SUCCESSFUL_OUTCOME, None
+
+    def _prepare_rerender(self, render_context: RenderContext):
+        frid = render_context.render_range[0]
+
+        if "." in frid:
+            render_context.dispatch_error(
+                f"--rerender only supports top-level integer FRIDs (e.g. `1`, `2`). "
+                f"Nested FRID `{frid}` is not supported."
+            )
+            return "error", None
+
+        if not git_utils.has_commit_for_frid(render_context.build_folder, frid, render_context.module_name):
+            render_context.dispatch_error(
+                f"Cannot re-render functionality {frid} because it has not been fully rendered yet. "
+                f"Please render all functionalities first by running: "
+                f"codeplain {render_context.module_name}.plain"
+            )
+            return "error", None
+
+        render_context.starting_frid = frid
+
+        module_metadata = render_context.plain_module.load_module_metadata()
+        if not module_metadata or "functionalities" not in module_metadata:
+            render_context.dispatch_error(
+                "module_metadata.json is missing or incomplete. "
+                "Please re-render the module from the beginning."
+            )
+            return "error", None
+
+        render_context.old_frid_spec = module_metadata["functionalities"][int(frid) - 1]
+
+        if render_context.render_conformance_tests:
+            conformance_tests_json = render_context.conformance_tests.get_conformance_tests_json(
+                render_context.module_name
+            )
+            if frid in conformance_tests_json:
+                old_folder = conformance_tests_json[frid]["folder_name"]
+                file_utils.delete_folder(old_folder)
+                del conformance_tests_json[frid]
+                render_context.conformance_tests.dump_conformance_tests_json(
+                    render_context.module_name, conformance_tests_json
                 )
 
         return self.SUCCESSFUL_OUTCOME, None

--- a/render_machine/actions/prepare_repositories.py
+++ b/render_machine/actions/prepare_repositories.py
@@ -104,8 +104,7 @@ class PrepareRepositories(BaseAction):
         module_metadata = render_context.plain_module.load_module_metadata()
         if not module_metadata or "functionalities" not in module_metadata:
             render_context.dispatch_error(
-                "module_metadata.json is missing or incomplete. "
-                "Please re-render the module from the beginning."
+                "module_metadata.json is missing or incomplete. " "Please re-render the module from the beginning."
             )
             return "error", None
 

--- a/render_machine/actions/prepare_testing_environment.py
+++ b/render_machine/actions/prepare_testing_environment.py
@@ -12,6 +12,12 @@ class PrepareTestingEnvironment(BaseAction):
     FAILED_OUTCOME = "testing_environment_preparation_failed"
 
     def execute(self, render_context: RenderContext, _previous_action_payload: Any | None):
+        if (
+            render_context.prepare_environment_script is None
+            or not render_context.conformance_tests_running_context.should_prepare_testing_environment
+        ):
+            return self.SUCCESSFUL_OUTCOME, None
+
         console.info(
             f"Running testing environment preparation script {render_context.prepare_environment_script} for build folder {render_context.build_folder}."
         )

--- a/render_machine/actions/render_conformance_tests.py
+++ b/render_machine/actions/render_conformance_tests.py
@@ -126,6 +126,7 @@ class RenderConformanceTests(BaseAction):
             ),
             all_acceptance_tests,
             run_state=render_context.run_state,
+            is_reimplementation=render_context.is_rerender,
         )
 
         render_context.conformance_tests_running_context.current_testing_frid_high_level_implementation_plan = (

--- a/render_machine/actions/render_functional_requirement.py
+++ b/render_machine/actions/render_functional_requirement.py
@@ -16,8 +16,22 @@ MAX_CODE_GENERATION_RETRIES = 2
 class RenderFunctionalRequirement(BaseAction):
     SUCCESSFUL_OUTCOME = "code_and_unit_tests_generated"
     FUNCTIONAL_REQUIREMENT_TOO_COMPLEX_OUTCOME = "functional_requirement_too_complex"
+    ITERATION_LIMIT_EXCEEDED_OUTCOME = "frid_iteration_limit_exceeded"
 
     def execute(self, render_context: RenderContext, _previous_action_payload: Any | None):
+        if render_context.frid_context.functional_requirement_render_attempts >= MAX_CODE_GENERATION_RETRIES:
+            error_msg = f"Unittests could not be fixed after rendering the functionality {render_context.frid_context.frid} for the {MAX_CODE_GENERATION_RETRIES} times."
+            render_context.last_error_message = error_msg
+            return self.ITERATION_LIMIT_EXCEEDED_OUTCOME, None
+
+        render_context.frid_context.functional_requirement_render_attempts += 1
+
+        if render_context.frid_context.functional_requirement_render_attempts > 1:
+            console.info(
+                f"Unittests could not be fixed after rendering the functionality. "
+                f"Restarting rendering functionality {render_context.frid_context.frid} from scratch."
+            )
+
         render_utils.revert_changes_for_frid(render_context)
         existing_files, existing_files_content = ImplementationCodeHelpers.fetch_existing_files(
             render_context.build_folder

--- a/render_machine/actions/render_functional_requirement.py
+++ b/render_machine/actions/render_functional_requirement.py
@@ -60,6 +60,8 @@ class RenderFunctionalRequirement(BaseAction):
                 render_context.get_required_modules_functionalities(),
                 render_context.should_run_unit_tests(),
                 render_context.run_state,
+                is_reimplementation=render_context.is_rerender,
+                old_functional_requirement_text=render_context.old_frid_spec,
             )
         except FunctionalRequirementTooComplex as e:
             error_message = f"The functionality:\n{render_context.frid_context.functional_requirement_text}\n is too complex to be implemented. Please break down the functionality into smaller parts ({str(e)})."

--- a/render_machine/actions/render_functional_requirement.py
+++ b/render_machine/actions/render_functional_requirement.py
@@ -63,6 +63,7 @@ class RenderFunctionalRequirement(BaseAction):
                 render_context.run_state,
                 is_reimplementation=render_context.is_rerender,
                 old_functional_requirement_text=render_context.old_frid_spec,
+                code_functional_requirements=render_context.code_functional_requirements,
             )
         except FunctionalRequirementTooComplex as e:
             error_message = f"The functionality:\n{render_context.frid_context.functional_requirement_text}\n is too complex to be implemented. Please break down the functionality into smaller parts."

--- a/render_machine/actions/render_functional_requirement.py
+++ b/render_machine/actions/render_functional_requirement.py
@@ -61,6 +61,8 @@ class RenderFunctionalRequirement(BaseAction):
                 render_context.get_required_modules_functionalities(),
                 render_context.should_run_unit_tests(),
                 render_context.run_state,
+                is_reimplementation=render_context.is_rerender,
+                old_functional_requirement_text=render_context.old_frid_spec,
             )
         except FunctionalRequirementTooComplex as e:
             error_message = f"The functionality:\n{render_context.frid_context.functional_requirement_text}\n is too complex to be implemented. Please break down the functionality into smaller parts."

--- a/render_machine/render_context.py
+++ b/render_machine/render_context.py
@@ -382,11 +382,18 @@ class RenderContext:
     def _has_reached_implementation_frid(self) -> bool:
         """Check if regression has reached the FRID being implemented."""
         ctx = self.conformance_tests_running_context
-        return (
+        if not (
             ctx.execution_phase == TestExecutionPhase.RUNNING_REGRESSION
             and ctx.current_testing_module_name == self.module_name
-            and (ctx.current_testing_frid is None or ctx.current_testing_frid == ctx.frid_being_implemented)
+        ):
+            return False
+
+        terminal_frid = (
+            list(plain_spec.get_frids(self.plain_source_tree))[-1]
+            if self.is_rerender
+            else ctx.frid_being_implemented
         )
+        return ctx.current_testing_frid is None or ctx.current_testing_frid == terminal_frid
 
     def _setup_test_specifications(self):
         """Load specifications for the current test."""

--- a/render_machine/render_context.py
+++ b/render_machine/render_context.py
@@ -310,13 +310,6 @@ class RenderContext:
             )
             self.machine.dispatch(triggers.PROCEED_FRID_PROCESSING)
 
-    def start_testing_environment_preparation(self):
-        if (
-            self.prepare_environment_script is None
-            or not self.conformance_tests_running_context.should_prepare_testing_environment
-        ):
-            self.machine.dispatch(triggers.MARK_TESTING_ENVIRONMENT_PREPARED)
-
     def start_conformance_tests_processing(self):
         console.info("Implementing conformance tests...")
         current_frid_specifications, _ = plain_spec.get_specifications_for_frid(
@@ -534,7 +527,6 @@ class RenderContext:
 
             self.machine.dispatch(triggers.MARK_CONFORMANCE_TESTS_READY)
 
-    # TODO why is this in the context and not part of the state machine (in an action)
     # ========== Main Conformance Test Orchestration ==========
 
     def start_conformance_tests_for_frid(self):

--- a/render_machine/render_context.py
+++ b/render_machine/render_context.py
@@ -389,9 +389,7 @@ class RenderContext:
             return False
 
         terminal_frid = (
-            list(plain_spec.get_frids(self.plain_source_tree))[-1]
-            if self.is_rerender
-            else ctx.frid_being_implemented
+            list(plain_spec.get_frids(self.plain_source_tree))[-1] if self.is_rerender else ctx.frid_being_implemented
         )
         return ctx.current_testing_frid is None or ctx.current_testing_frid == terminal_frid
 
@@ -513,6 +511,14 @@ class RenderContext:
         self._setup_test_specifications()
 
         if ctx.current_conformance_tests_exist():
+            if self.is_rerender and ctx.current_testing_frid == ctx.frid_being_implemented:
+                # already tested in the initial phase — skip and advance to next
+                self.conformance_tests_running_context = self._get_next_test_to_run()
+                ctx = self.conformance_tests_running_context
+                self._setup_test_specifications()
+                if not ctx.current_conformance_tests_exist():
+                    return
+
             # Check if this is the implementation FRID (last test to run)
             if self._has_reached_implementation_frid():
                 # Reached implementation FRID - only re-run it if code changed during regression
@@ -528,6 +534,7 @@ class RenderContext:
 
             self.machine.dispatch(triggers.MARK_CONFORMANCE_TESTS_READY)
 
+    # TODO why is this in the context and not part of the state machine (in an action)
     # ========== Main Conformance Test Orchestration ==========
 
     def start_conformance_tests_for_frid(self):

--- a/render_machine/render_context.py
+++ b/render_machine/render_context.py
@@ -23,7 +23,6 @@ from render_machine.render_types import (
 )
 
 MAX_UNITTEST_FIX_ATTEMPTS = 20
-MAX_CODE_GENERATION_RETRIES = 2
 MAX_CONFORMANCE_TEST_RERENDER_ATTEMPTS = 1
 MAX_REFACTORING_ITERATIONS = 5
 MAX_CONFORMANCE_TEST_FIX_ATTEMPTS = 20
@@ -163,20 +162,6 @@ class RenderContext:
             functional_requirement_render_attempts=0,
         )
         return
-
-    def check_frid_iteration_limit(self):
-        if self.frid_context.functional_requirement_render_attempts >= MAX_CODE_GENERATION_RETRIES:
-            error_msg = f"Unittests could not be fixed after rendering the functionality {self.frid_context.frid} for the {MAX_CODE_GENERATION_RETRIES} times."
-            self.dispatch_error(error_msg)
-
-        self.frid_context.functional_requirement_render_attempts += 1
-
-        if self.frid_context.functional_requirement_render_attempts > 1:
-            # this if is intended just for logging
-            console.info(
-                f"Unittests could not be fixed after rendering the functionality. "
-                f"Restarting rendering the functionality {self.frid_context.frid} from scratch."
-            )
 
     def has_next_frid(self) -> bool:
         next_frid = plain_spec.get_next_frid(self.plain_source_tree, self.frid_context.frid)

--- a/render_machine/render_context.py
+++ b/render_machine/render_context.py
@@ -52,6 +52,7 @@ class RenderContext:
         test_script_timeout: Optional[int] = None,
         stop_event: Optional[threading.Event] = None,
         enter_pause_event: Optional[threading.Event] = None,
+        is_rerender: bool = False,
     ):
         self.codeplain_api: CodeplainAPI = codeplain_api
         self.memory_manager = memory_manager
@@ -76,6 +77,8 @@ class RenderContext:
         self.event_bus = event_bus
         self.stop_event = stop_event
         self.enter_pause_event = enter_pause_event
+        self.is_rerender = is_rerender
+        self.old_frid_spec: str | None = None
         self.script_execution_history = ScriptExecutionHistory()
         self.starting_frid = None
         self.test_script_timeout = test_script_timeout

--- a/render_machine/render_context.py
+++ b/render_machine/render_context.py
@@ -48,6 +48,7 @@ class RenderContext:
         test_script_timeout: Optional[int] = None,
         stop_event: Optional[threading.Event] = None,
         enter_pause_event: Optional[threading.Event] = None,
+        is_rerender: bool = False,
     ):
         self.codeplain_api: CodeplainAPI = codeplain_api
         self.memory_manager = memory_manager
@@ -71,6 +72,8 @@ class RenderContext:
         self.event_bus = event_bus
         self.stop_event = stop_event
         self.enter_pause_event = enter_pause_event
+        self.is_rerender = is_rerender
+        self.old_frid_spec: str | None = None
         self.script_execution_history = ScriptExecutionHistory()
         self.starting_frid = None
         self.test_script_timeout = test_script_timeout

--- a/render_machine/render_context.py
+++ b/render_machine/render_context.py
@@ -372,11 +372,18 @@ class RenderContext:
     def _has_reached_implementation_frid(self) -> bool:
         """Check if regression has reached the FRID being implemented."""
         ctx = self.conformance_tests_running_context
-        return (
+        if not (
             ctx.execution_phase == TestExecutionPhase.RUNNING_REGRESSION
             and ctx.current_testing_module_name == self.module_name
-            and (ctx.current_testing_frid is None or ctx.current_testing_frid == ctx.frid_being_implemented)
+        ):
+            return False
+
+        terminal_frid = (
+            list(plain_spec.get_frids(self.plain_source_tree))[-1]
+            if self.is_rerender
+            else ctx.frid_being_implemented
         )
+        return ctx.current_testing_frid is None or ctx.current_testing_frid == terminal_frid
 
     def _setup_test_specifications(self):
         """Load specifications for the current test."""

--- a/render_machine/render_context.py
+++ b/render_machine/render_context.py
@@ -74,6 +74,7 @@ class RenderContext:
         self.enter_pause_event = enter_pause_event
         self.is_rerender = is_rerender
         self.old_frid_spec: str | None = None
+        self.code_functional_requirements: list[str] | None = None
         self.script_execution_history = ScriptExecutionHistory()
         self.starting_frid = None
         self.test_script_timeout = test_script_timeout

--- a/render_machine/render_context.py
+++ b/render_machine/render_context.py
@@ -379,9 +379,7 @@ class RenderContext:
             return False
 
         terminal_frid = (
-            list(plain_spec.get_frids(self.plain_source_tree))[-1]
-            if self.is_rerender
-            else ctx.frid_being_implemented
+            list(plain_spec.get_frids(self.plain_source_tree))[-1] if self.is_rerender else ctx.frid_being_implemented
         )
         return ctx.current_testing_frid is None or ctx.current_testing_frid == terminal_frid
 
@@ -503,6 +501,14 @@ class RenderContext:
         self._setup_test_specifications()
 
         if ctx.current_conformance_tests_exist():
+            if self.is_rerender and ctx.current_testing_frid == ctx.frid_being_implemented:
+                # already tested in the initial phase — skip and advance to next
+                self.conformance_tests_running_context = self._get_next_test_to_run()
+                ctx = self.conformance_tests_running_context
+                self._setup_test_specifications()
+                if not ctx.current_conformance_tests_exist():
+                    return
+
             # Check if this is the implementation FRID (last test to run)
             if self._has_reached_implementation_frid():
                 # Reached implementation FRID - only re-run it if code changed during regression
@@ -518,6 +524,7 @@ class RenderContext:
 
             self.machine.dispatch(triggers.MARK_CONFORMANCE_TESTS_READY)
 
+    # TODO why is this in the context and not part of the state machine (in an action)
     # ========== Main Conformance Test Orchestration ==========
 
     def start_conformance_tests_for_frid(self):

--- a/render_machine/render_utils.py
+++ b/render_machine/render_utils.py
@@ -27,6 +27,8 @@ PIPE_SIZE_KB = 1024  # 1MB
 
 
 def revert_changes_for_frid(render_context):
+    if render_context.is_rerender:
+        return
     if render_context.frid_context.frid is not None:
         previous_frid = plain_spec.get_previous_frid(render_context.plain_source_tree, render_context.frid_context.frid)
         git_utils.revert_to_commit_with_frid(render_context.build_folder, previous_frid)

--- a/render_machine/render_utils.py
+++ b/render_machine/render_utils.py
@@ -26,6 +26,8 @@ PIPE_SIZE_KB = 1024  # 1MB
 
 
 def revert_changes_for_frid(render_context):
+    if render_context.is_rerender:
+        return
     if render_context.frid_context.frid is not None:
         previous_frid = plain_spec.get_previous_frid(render_context.plain_source_tree, render_context.frid_context.frid)
         render_context.plain_module.revert_code_to_frid(previous_frid)

--- a/render_machine/state_machine_config.py
+++ b/render_machine/state_machine_config.py
@@ -133,10 +133,7 @@ class StateMachineConfig:
                     "name": States.CONFORMANCE_TESTING_INITIALISED.value,
                     "on_enter": render_context.start_conformance_tests_for_frid,
                 },
-                {
-                    "name": States.CONFORMANCE_TEST_GENERATED.value,
-                    "on_enter": render_context.start_testing_environment_preparation,
-                },
+                States.CONFORMANCE_TEST_GENERATED.value,
                 States.CONFORMANCE_TEST_ENV_PREPARED.value,
                 {
                     "name": States.CONFORMANCE_TEST_FAILED.value,

--- a/render_machine/state_machine_config.py
+++ b/render_machine/state_machine_config.py
@@ -73,6 +73,7 @@ class StateMachineConfig:
             PrepareRepositories.SUCCESSFUL_OUTCOME: triggers.START_RENDER,
             RenderFunctionalRequirement.SUCCESSFUL_OUTCOME: triggers.RENDER_FUNCTIONAL_REQUIREMENT,
             RenderFunctionalRequirement.FUNCTIONAL_REQUIREMENT_TOO_COMPLEX_OUTCOME: triggers.HANDLE_ERROR,
+            RenderFunctionalRequirement.ITERATION_LIMIT_EXCEEDED_OUTCOME: triggers.HANDLE_ERROR,
             RunUnitTests.SUCCESSFUL_OUTCOME: triggers.MARK_UNIT_TESTS_PASSED,
             RunUnitTests.FAILED_OUTCOME: triggers.MARK_UNIT_TESTS_FAILED,
             RunUnitTests.UNRECOVERABLE_ERROR_OUTCOME: triggers.HANDLE_ERROR,
@@ -183,10 +184,7 @@ class StateMachineConfig:
                 "on_exit": render_context.finish_implementing_frid,
                 "children": [
                     {"name": States.STEP_COMPLETED.value},
-                    {
-                        "name": States.READY_FOR_FRID_IMPLEMENTATION.value,
-                        "on_enter": render_context.check_frid_iteration_limit,
-                    },
+                    States.READY_FOR_FRID_IMPLEMENTATION.value,
                     self.get_processing_unit_tests_states(
                         render_context, render_context._on_unit_test_limit_exceeded_in_implementation
                     ),

--- a/render_machine/state_machine_config.py
+++ b/render_machine/state_machine_config.py
@@ -55,12 +55,9 @@ class StateMachineConfig:
             f"{States.IMPLEMENTING_FRID.value}_{States.PROCESSING_CONFORMANCE_TESTS.value}_{States.POSTPROCESSING_CONFORMANCE_TESTS.value}_{States.CONFORMANCE_TESTS_READY_FOR_SUMMARY.value}": SummarizeConformanceTests(),
             f"{States.IMPLEMENTING_FRID.value}_{States.PROCESSING_CONFORMANCE_TESTS.value}_{States.POSTPROCESSING_CONFORMANCE_TESTS.value}_{States.CONFORMANCE_TESTS_READY_FOR_COMMIT.value}": CommitConformanceTestsChanges(
                 git_utils.CONFORMANCE_TESTS_PASSED_COMMIT_MESSAGE,
-                git_utils.FUNCTIONAL_REQUIREMENT_FINISHED_COMMIT_MESSAGE,
             ),
             f"{States.IMPLEMENTING_FRID.value}_{States.PROCESSING_CONFORMANCE_TESTS.value}_{States.POSTPROCESSING_CONFORMANCE_TESTS.value}_{States.CONFORMANCE_TESTS_READY_FOR_AMBIGUITY_ANALYSIS.value}": AnalyzeSpecificationAmbiguity(),
-            f"{States.IMPLEMENTING_FRID.value}_{States.FRID_FULLY_IMPLEMENTED.value}": FinishFunctionalRequirement(
-                git_utils.FUNCTIONAL_REQUIREMENT_FINISHED_COMMIT_MESSAGE
-            ),
+            f"{States.IMPLEMENTING_FRID.value}_{States.FRID_FULLY_IMPLEMENTED.value}": FinishFunctionalRequirement(),
             f"{States.IMPLEMENTING_FRID.value}_{States.PROCESSING_CONFORMANCE_TESTS.value}_{States.PROCESSING_UNIT_TESTS.value}_{States.UNIT_TESTS_READY.value}": RunUnitTests(),
             f"{States.IMPLEMENTING_FRID.value}_{States.PROCESSING_CONFORMANCE_TESTS.value}_{States.PROCESSING_UNIT_TESTS.value}_{States.UNIT_TESTS_FAILED.value}": FixUnitTests(),
             States.RENDER_COMPLETED.value: CreateDist(),

--- a/tests/test_prepare_repositories_layout.py
+++ b/tests/test_prepare_repositories_layout.py
@@ -43,6 +43,7 @@ def solo_module(get_test_data_path, tmp_build_folder):
 def _make_render_context(module: PlainModule, render_conformance_tests: bool) -> SimpleNamespace:
     return SimpleNamespace(
         render_range=None,
+        is_rerender=False,
         plain_module=module,
         required_modules=module.required_modules,
         build_folder=module.module_build_folder,


### PR DESCRIPTION
This adds a way to rerender a single functionality in a project that has been completely rendered before.

Usage: `codeplain --rerender 2 project.plain`

### How it works:

1. it checks if the project has been rendered and it removes the conformance tests for the functionality that is being rerendered (e.g.: FR 2 in a project with 4 FRs).
2. it gets the old specs of FR 2 and it provides them to the `render_functional_requirement` call. It also instructs the model to do a rerender and that code related to old specs must be removed (see https://github.com/Codeplain-ai/plain2code_rest_api/pull/105)
3. then it applies a commit with the implementation changes on top of the other commits (with a different commit message) and it also runs the conformance test for FR 2
4. then it runs all of the other conformance tests (1, 3, 4)
5. it also updates module_metadata.json with the new FR specs and hash

### Example
Example run on a project with 4 FRs:

```
***functional specs***
- :User: should be able to add :Task:. Only valid :Task: items can be added.
- :User: should be able to delete :Task:
- :User: should be able to view :Task: name, notes, due date, and status by running the :App: with CLI argument --view <task_id>.
- Show :TaskList:
```

Then I changed number 3 to:
```
- :User: should be able to mark :Task: as completed.
```

and I ran it with `--rerender 3`.

This are the logs: 
[codeplain.log](https://github.com/user-attachments/files/28756425/codeplain.log)

The commits in the rendered module:
```
* c87ec04 (HEAD -> main) [Codeplain] functionality ID (FRID):3 fully reimplemented
* 11d5bca [Codeplain] Fixed issues in the implementation code identified during conformance testing
* 2a29914 [Codeplain] Implemented code and unit tests for functionality 3
* 5dc2e76 [Codeplain] functionality ID (FRID):4 fully implemented
* d0a4199 [Codeplain] Implemented code and unit tests for functionality 4
* 5f405ad [Codeplain] functionality ID (FRID):3 fully implemented
* 00960ac [Codeplain] Implemented code and unit tests for functionality 3
* a2fc0f7 [Codeplain] functionality ID (FRID):2 fully implemented
* dc2a6d2 [Codeplain] Fixed issues in the implementation code identified during conformance testing
* a1ca663 [Codeplain] Implemented code and unit tests for functionality 2
* c6b0c86 [Codeplain] functionality ID (FRID):1 fully implemented
* 42489c3 [Codeplain] Implemented code and unit tests for functionality 1
* 1ba6c4a [Codeplain] Initial module commit
```

Commits in the conformance_tests:
```
* e8f0ae8 (HEAD -> main) - :User: should be able to mark :Task: as completed.
* 85f7947 - Show :TaskList:
* 7ea42af - :User: should be able to view :Task: name, notes, due date, and status by running the :App: with CLI argument --view <task_id>.
* 7d2a1ee - :User: should be able to delete :Task:
* 889e153 - :User: should be able to add :Task:. Only valid :Task: items can be added.
* e28ad48 [Codeplain] Initial module commitq
```

The conformance tests:
```
conformance_tests.json
task_addition_validation
task_completion_verification
task_deletion_verification
task_list_display_verification
```

And the implementation code was changed too and the stuff related to the old spec was removed.

`80cf5ee7-bcb5-4094-b293-e0d73a57f45c`

### Additional notes:
- it shouldn't be a surprise but still worth noting that: running codeplain with `--render-from N` on a project that has had `--rerender` used on it will still make the tool render the range from  N-1. The "reimplementation" commits will get discarded anyway.
- this branch is based on the `impr/state-machine-cleanup` branch, I will rebase this once that's merged