### PR TITLE
 Build the git-detected check mark from its code point

### DIFF
--- a/install/powershell/install.ps1
+++ b/install/powershell/install.ps1
@@ -195,7 +195,7 @@ if (-not (Test-GitAvailable)) {
     Assert-Git
 }
 
-Write-Host "${GREEN}✓${NC} git detected"
+Write-Host "${GREEN}${CHECK} ${NC} git detected"
 Write-Host ""
 
 try {


### PR DESCRIPTION
  install.ps1 is UTF-8 without a BOM, so Windows PowerShell 5.1 decodes it
  as CP1252, where the literal U+2713 on the "git detected" line becomes a
  smart quote that terminates the enclosing string. The script then fails
  to parse and installs nothing; only `irm ... | iex` was unaffected, since
  that decodes as UTF-8 over HTTP.