### PR TITLE
Adding missing predefined concepts.

### DIFF
--- a/concept_utils.py
+++ b/concept_utils.py
@@ -13,7 +13,13 @@ DEFAULT_CONCEPTS = {
     ":ConformanceTests:",
     ":UnitTests:",
     ":AcceptanceTests:",
+    ":AcceptanceTests:",
     ":Implementation:",
+    ":plainDefinitions:",
+    ":plainImplementationReqs:",
+    ":plainFunctionality:",
+    ":plainTestReqs:",
+    ":plainImplementationCode:",
 }
 
 

--- a/concept_utils.py
+++ b/concept_utils.py
@@ -12,7 +12,7 @@ from plain2code_exceptions import PlainSyntaxError
 DEFAULT_CONCEPTS = {
     ":ConformanceTests:",
     ":UnitTests:",
-    ":AcceptanceTests:",
+    ":AcceptanceTest:",
     ":AcceptanceTests:",
     ":Implementation:",
     ":plainDefinitions:",


### PR DESCRIPTION
Not all predefined concepts from https://www.plainlang.org/docs/language-guide/definitions/predefined-concepts were listed as such in codeplain client. Fixing this with this pull request.