### PR TITLE
Disable Rich's repr highlighter on the log path

### DIFF
--- a/plain2code_console.py
+++ b/plain2code_console.py
@@ -67,8 +67,10 @@ class Plain2CodeConsole(Console):
         logger.log(level, " ".join(map(str, args)), extra={"log_color": color})
         style = base_style + Style(color=color) if color else base_style
         # Log messages must render exactly as logged: don't interpret square brackets
-        # in interpolated content (error texts, file names) as Rich markup.
+        # in interpolated content (error texts, file names) as Rich markup, and don't
+        # let the repr highlighter restyle brackets and numbers inside them.
         kwargs.setdefault("markup", False)
+        kwargs.setdefault("highlight", False)
         super().print(*args, **kwargs, style=style)
 
     def print_list(self, items, style=None):


### PR DESCRIPTION
`markup=False` was already set so that a log message renders exactly as logged, but Rich's repr highlighter still restyled brackets and numbers inside the text. On a colour-capable terminal that spliced ANSI codes into error messages and file names — `[Errno 8]` came out with the brackets and the digit in different colours.

This sets `highlight=False` on the same call to render exactly as logged also under pty environment.