### PR TITLE
Run the test suite on macOS and Windows

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -72,8 +72,15 @@ jobs:
         run: flake8 .
 
   mypy:
-    name: MyPy Type Checking
+    name: MyPy Type Checking (${{ matrix.platform }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # --platform is a static narrowing setting, so every target is checked from
+        # one runner: code is verified under the platform where it runs and proven
+        # guarded under the platforms where it does not.
+        platform: [linux, darwin, win32]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -90,37 +97,45 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
       - name: Type check with mypy
-        run: mypy . --check-untyped-defs
+        run: mypy . --check-untyped-defs --platform ${{ matrix.platform }}
 
   tests:
-    name: Run Tests
-    runs-on: ubuntu-latest
+    name: Run Tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-      - name: Configure git for tests
-        run: |
-          git config --global user.email "test@example.com"
-          git config --global user.name "Test Runner"
-          git config --global init.defaultBranch main
-      - name: Cache pip
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install coverage
+          cache: pip
+          cache-dependency-path: requirements.txt
+      # Every step below runs a single command. Windows runners default to
+      # PowerShell, where a failing native command does not abort the remaining
+      # commands of a multi-command run block; one command per step makes a
+      # failure fail the job on every OS without shell-specific workarounds.
+      - name: Configure git user email
+        run: git config --global user.email "test@example.com"
+      - name: Configure git user name
+        run: git config --global user.name "Test Runner"
+      - name: Configure git default branch
+        run: git config --global init.defaultBranch main
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+      - name: Install requirements
+        run: pip install -r requirements.txt
+      - name: Install coverage
+        run: pip install coverage
       - name: Run tests with coverage
-        run: |
-          export $(cat .env.dev.example | xargs)
-          coverage run -m pytest tests/ -v
-          coverage xml
-          coverage report
+        run: coverage run -m pytest tests/ -v
+      - name: Generate coverage XML
+        run: coverage xml
+      - name: Show coverage report
+        run: coverage report
       - name: Upload coverage reports
+        if: matrix.os == 'ubuntu-latest'
         uses: codecov/codecov-action@v3

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ dist
 
 .coverage
 logging_config.yaml
+/.idea/

--- a/file_utils.py
+++ b/file_utils.py
@@ -103,6 +103,24 @@ def delete_folder(folder_name):
         shutil.rmtree(folder_name, onerror=_on_rm_error)
 
 
+def _on_rm_error_best_effort(func, path, _exc_info):
+    """Clear the read-only flag and retry; give up quietly if that does not help."""
+    try:
+        os.chmod(path, stat.S_IWRITE)
+        func(path)
+    except OSError:
+        pass
+
+
+def delete_folder_best_effort(folder_name):
+    """Delete a folder without failing the caller if part of it survives.
+
+    shutil.rmtree's ignore_errors skips a read-only file rather than clearing the flag,
+    so on Windows a folder holding a git object store is left behind.
+    """
+    shutil.rmtree(folder_name, onerror=_on_rm_error_best_effort)
+
+
 def delete_files_and_subfolders(directory):
     """Delete all contents of a directory but keep the directory itself."""
     for entry in os.scandir(directory):

--- a/git_utils.py
+++ b/git_utils.py
@@ -331,6 +331,19 @@ def has_commit_for_frid(repo_path: Union[str, os.PathLike], frid: str, module_na
         return bool(_get_commit_with_frid(repo, frid, module_name))
 
 
+def frids_missing_commits(
+    repo_path: Union[str, os.PathLike], frids: list[str], module_name: Optional[str] = None
+) -> list[str]:
+    """The frids from `frids` with no commit in the repository, in the order given.
+
+    One Repo answers for the whole list. Asking per frid instead opens and closes a Repo
+    each time, and close() runs gc.collect() twice on win32, so a render resumed late paid
+    that for every functionality before it.
+    """
+    with Repo(repo_path) as repo:
+        return [frid for frid in frids if not _get_commit_with_frid(repo, frid, module_name)]
+
+
 def _get_base_folder_commit(repo: Repo) -> str:
     """Finds commit related to copy of the base folder."""
     return _get_commit_with_message(repo, BASE_FOLDER_COMMIT_MESSAGE)

--- a/git_utils.py
+++ b/git_utils.py
@@ -43,21 +43,20 @@ def _get_full_commit_message(message, module_name, frid, render_id) -> str:
 
 
 def _ensure_git_config(repo: Repo) -> None:
-    config = repo.config_reader()
+    with repo.config_reader() as config:
+        try:
+            config.get_value("user", "name")
+        except (NoSectionError, NoOptionError):
+            # user.name not configured, set a default at repo level
+            with repo.config_writer(config_level="repository") as writer:
+                writer.set_value("user", "name", "Codeplain")
 
-    try:
-        config.get_value("user", "name")
-    except (NoSectionError, NoOptionError):
-        # user.name not configured, set a default at repo level
-        with repo.config_writer(config_level="repository") as writer:
-            writer.set_value("user", "name", "Codeplain")
-
-    try:
-        config.get_value("user", "email")
-    except (NoSectionError, NoOptionError):
-        # user.email not configured, set a default at repo level
-        with repo.config_writer(config_level="repository") as writer:
-            writer.set_value("user", "email", "codeplain@localhost")
+        try:
+            config.get_value("user", "email")
+        except (NoSectionError, NoOptionError):
+            # user.email not configured, set a default at repo level
+            with repo.config_writer(config_level="repository") as writer:
+                writer.set_value("user", "email", "codeplain@localhost")
 
 
 def init_git_repo(
@@ -75,12 +74,16 @@ def init_git_repo(
     else:
         os.makedirs(path_to_repo)
 
-    repo = Repo.init(path_to_repo)
-    _ensure_git_config(repo)
+    # Every function here closes its Repo before returning: GitPython's persistent
+    # `git cat-file` children are only reaped by close(), and on Windows a live child
+    # keeps the repository directory undeletable. A closed Repo stays usable — it
+    # re-acquires its resources lazily — so returning it is safe.
+    with Repo.init(path_to_repo) as repo:
+        _ensure_git_config(repo)
 
-    repo.git.commit(
-        "--allow-empty", "-m", _get_full_commit_message(INITIAL_COMMIT_MESSAGE, module_name, None, render_id)
-    )
+        repo.git.commit(
+            "--allow-empty", "-m", _get_full_commit_message(INITIAL_COMMIT_MESSAGE, module_name, None, render_id)
+        )
 
     return repo
 
@@ -91,17 +94,18 @@ def clone_repo(
     module_name: Optional[str] = None,
     render_id: Optional[str] = None,
 ) -> Repo:
-    repo = Repo.clone_from(source_repo_path, new_repo_path)
+    with Repo.clone_from(source_repo_path, new_repo_path) as repo:
+        repo.git.commit(
+            "--allow-empty", "-m", _get_full_commit_message(INITIAL_COMMIT_MESSAGE, module_name, None, render_id)
+        )
 
-    repo.git.commit(
-        "--allow-empty", "-m", _get_full_commit_message(INITIAL_COMMIT_MESSAGE, module_name, None, render_id)
-    )
+    return repo
 
 
 def is_dirty(repo_path: Union[str, os.PathLike]) -> bool:
     """Checks if the repository is dirty."""
-    repo = Repo(repo_path)
-    return repo.is_dirty(untracked_files=True)
+    with Repo(repo_path) as repo:
+        return repo.is_dirty(untracked_files=True)
 
 
 def add_all_files_and_commit(
@@ -112,25 +116,25 @@ def add_all_files_and_commit(
     render_id: Optional[str] = None,
 ) -> Repo:
     """Adds all files to the git repository and commits them."""
-    repo = Repo(repo_path)
-    repo.git.add(".")
+    with Repo(repo_path) as repo:
+        repo.git.add(".")
 
-    message = _get_full_commit_message(commit_message, module_name, frid, render_id)
+        message = _get_full_commit_message(commit_message, module_name, frid, render_id)
 
-    # Check if there are any changes to commit
-    if not repo.is_dirty(untracked_files=True):
-        repo.git.commit("--allow-empty", "-m", message)
-    else:
-        repo.git.commit("-m", message)
+        # Check if there are any changes to commit
+        if not repo.is_dirty(untracked_files=True):
+            repo.git.commit("--allow-empty", "-m", message)
+        else:
+            repo.git.commit("-m", message)
 
     return repo
 
 
 def revert_changes(repo_path: Union[str, os.PathLike]) -> Repo:
     """Reverts all changes made since the last commit."""
-    repo = Repo(repo_path)
-    repo.git.reset("--hard")
-    repo.git.clean("-xdf")
+    with Repo(repo_path) as repo:
+        repo.git.reset("--hard")
+        repo.git.clean("-xdf")
     return repo
 
 
@@ -144,15 +148,16 @@ def revert_to_commit_with_frid(repo_path: Union[str, os.PathLike], frid: Optiona
     It is expected that the repo has at least one commit related to provided frid if frid is not None.
     In case the frid related commit is not found, an exception is raised.
     """
-    repo = Repo(repo_path)
+    with Repo(repo_path) as repo:
+        commit = _get_commit(repo, frid)
 
-    commit = _get_commit(repo, frid)
+        if not commit:
+            raise InvalidGitRepositoryError(
+                "Git repository is in an invalid state. Relevant commit could not be found."
+            )
 
-    if not commit:
-        raise InvalidGitRepositoryError("Git repository is in an invalid state. Relevant commit could not be found.")
-
-    repo.git.reset("--hard", commit)
-    repo.git.clean("-xdf")
+        repo.git.reset("--hard", commit)
+        repo.git.clean("-xdf")
     return repo
 
 
@@ -166,14 +171,15 @@ def checkout_commit_with_frid(repo_path: Union[str, os.PathLike], frid: Optional
     It is expected that the repo has at least one commit related to provided frid if frid is not None.
     In case the frid related commit is not found, an exception is raised.
     """
-    repo = Repo(repo_path)
+    with Repo(repo_path) as repo:
+        commit = _get_commit(repo, frid)
 
-    commit = _get_commit(repo, frid)
+        if not commit:
+            raise InvalidGitRepositoryError(
+                "Git repository is in an invalid state. Relevant commit could not be found."
+            )
 
-    if not commit:
-        raise InvalidGitRepositoryError("Git repository is in an invalid state. Relevant commit could not be found.")
-
-    repo.git.checkout(commit)
+        repo.git.checkout(commit)
     return repo
 
 
@@ -187,8 +193,8 @@ def checkout_previous_branch(repo_path: Union[str, os.PathLike]) -> Repo:
     Returns:
         Repo: The git repository object
     """
-    repo = Repo(repo_path)
-    repo.git.checkout("-")
+    with Repo(repo_path) as repo:
+        repo.git.checkout("-")
     return repo
 
 
@@ -255,15 +261,14 @@ def diff(repo_path: Union[str, os.PathLike], previous_frid: str = None) -> dict:
     Returns:
         dict: Dictionary with file names as keys and their clean diff strings as values
     """
-    repo = Repo(repo_path)
+    with Repo(repo_path) as repo:
+        commit = _get_commit(repo, previous_frid)
 
-    commit = _get_commit(repo, previous_frid)
+        # Add all files to the index to get a clean diff
+        repo.git.add("-N", ".")
 
-    # Add all files to the index to get a clean diff
-    repo.git.add("-N", ".")
-
-    # Get the raw git diff output, excluding .pyc files
-    diff_output = repo.git.diff(commit, "--text", ":!*.pyc")
+        # Get the raw git diff output, excluding .pyc files
+        diff_output = repo.git.diff(commit, "--text", ":!*.pyc")
 
     if not diff_output:
         return {}
@@ -322,7 +327,8 @@ def _get_commit_with_frid(repo: Repo, frid: str, module_name: Optional[str] = No
 
 
 def has_commit_for_frid(repo_path: Union[str, os.PathLike], frid: str, module_name: Optional[str] = None) -> bool:
-    return bool(_get_commit_with_frid(Repo(repo_path), frid, module_name))
+    with Repo(repo_path) as repo:
+        return bool(_get_commit_with_frid(repo, frid, module_name))
 
 
 def _get_base_folder_commit(repo: Repo) -> str:
@@ -343,18 +349,17 @@ def _get_commit_with_message(repo: Repo, message: str) -> str:
 
 
 def get_implementation_code_diff(repo_path: Union[str, os.PathLike], frid: str, previous_frid: str) -> dict:
-    repo = Repo(repo_path)
+    with Repo(repo_path) as repo:
+        implementation_commit = _get_commit_with_message(repo, REFACTORED_CODE_COMMIT_MESSAGE.format(frid))
+        if not implementation_commit:
+            implementation_commit = _get_commit_with_message(
+                repo, FUNCTIONAL_REQUIREMENT_IMPLEMENTED_COMMIT_MESSAGE.format(frid)
+            )
 
-    implementation_commit = _get_commit_with_message(repo, REFACTORED_CODE_COMMIT_MESSAGE.format(frid))
-    if not implementation_commit:
-        implementation_commit = _get_commit_with_message(
-            repo, FUNCTIONAL_REQUIREMENT_IMPLEMENTED_COMMIT_MESSAGE.format(frid)
-        )
+        previous_frid_commit = _get_commit(repo, previous_frid)
 
-    previous_frid_commit = _get_commit(repo, previous_frid)
-
-    # Get the raw git diff output, excluding .pyc files
-    diff_output = repo.git.diff(previous_frid_commit, implementation_commit, "--text", ":!*.pyc")
+        # Get the raw git diff output, excluding .pyc files
+        diff_output = repo.git.diff(previous_frid_commit, implementation_commit, "--text", ":!*.pyc")
 
     if not diff_output:
         return {}
@@ -363,22 +368,21 @@ def get_implementation_code_diff(repo_path: Union[str, os.PathLike], frid: str, 
 
 
 def get_fixed_implementation_code_diff(repo_path: Union[str, os.PathLike], frid: str) -> dict:
-    repo = Repo(repo_path)
+    with Repo(repo_path) as repo:
+        implementation_commit = _get_commit_with_message(repo, REFACTORED_CODE_COMMIT_MESSAGE.format(frid))
+        if not implementation_commit:
+            implementation_commit = _get_commit_with_message(
+                repo, FUNCTIONAL_REQUIREMENT_IMPLEMENTED_COMMIT_MESSAGE.format(frid)
+            )
 
-    implementation_commit = _get_commit_with_message(repo, REFACTORED_CODE_COMMIT_MESSAGE.format(frid))
-    if not implementation_commit:
-        implementation_commit = _get_commit_with_message(
-            repo, FUNCTIONAL_REQUIREMENT_IMPLEMENTED_COMMIT_MESSAGE.format(frid)
+        conformance_tests_passed_commit = _get_commit_with_message(
+            repo, CONFORMANCE_TESTS_PASSED_COMMIT_MESSAGE.format(frid)
         )
+        if not conformance_tests_passed_commit:
+            return None
 
-    conformance_tests_passed_commit = _get_commit_with_message(
-        repo, CONFORMANCE_TESTS_PASSED_COMMIT_MESSAGE.format(frid)
-    )
-    if not conformance_tests_passed_commit:
-        return None
-
-    # Get the raw git diff output, excluding .pyc files
-    diff_output = repo.git.diff(implementation_commit, conformance_tests_passed_commit, "--text", ":!*.pyc")
+        # Get the raw git diff output, excluding .pyc files
+        diff_output = repo.git.diff(implementation_commit, conformance_tests_passed_commit, "--text", ":!*.pyc")
 
     if not diff_output:
         return {}
@@ -396,31 +400,30 @@ def get_repo_info(repo_path: Union[str, os.PathLike]) -> dict:
       - is_dirty: boolean (includes untracked files)
       - remotes: dict mapping remote name to list of URLs
     """
-    repo = Repo(repo_path)
+    with Repo(repo_path) as repo:
+        info = {"path": os.path.abspath(repo_path)}
 
-    info = {"path": os.path.abspath(repo_path)}
+        # Active branch (handle detached HEAD safely)
+        try:
+            if getattr(repo.head, "is_detached", False):
+                # Provide short commit identifier for detached head if available
+                try:
+                    commit_sha = repo.head.commit.hexsha[:7]
+                    info["active_branch"] = f"DETACHED_{commit_sha}"
+                except Exception:
+                    info["active_branch"] = "DETACHED"
+            else:
+                info["active_branch"] = repo.active_branch.name
+        except Exception:
+            info["active_branch"] = None
 
-    # Active branch (handle detached HEAD safely)
-    try:
-        if getattr(repo.head, "is_detached", False):
-            # Provide short commit identifier for detached head if available
-            try:
-                commit_sha = repo.head.commit.hexsha[:7]
-                info["active_branch"] = f"DETACHED_{commit_sha}"
-            except Exception:
-                info["active_branch"] = "DETACHED"
-        else:
-            info["active_branch"] = repo.active_branch.name
-    except Exception:
-        info["active_branch"] = None
+        info["is_dirty"] = repo.is_dirty(untracked_files=True)
 
-    info["is_dirty"] = repo.is_dirty(untracked_files=True)
-
-    # Remotes
-    remotes = {}
-    for remote in repo.remotes:
-        remotes[remote.name] = list(remote.urls)
-    info["remotes"] = remotes
+        # Remotes
+        remotes = {}
+        for remote in repo.remotes:
+            remotes[remote.name] = list(remote.urls)
+        info["remotes"] = remotes
 
     return info
 
@@ -429,35 +432,38 @@ def get_last_rendered_functionality(repo_path: Union[str, os.PathLike]) -> tuple
     if not os.path.exists(repo_path):
         return None, None
 
-    repo = Repo(repo_path)
-    grep_pattern = FUNCTIONAL_REQUIREMENT_FINISHED_COMMIT_MESSAGE.format(".*")
-    grep_pattern = grep_pattern.replace("[", "\\[").replace("]", "\\]")
-    commit_sha = repo.git.rev_list(repo.active_branch.name, "--grep", grep_pattern, "-n", "1")
-
-    if not commit_sha:
-        # Repo was interrupted during the first functionality, fallback to initial commit and provide only module name
-        grep_pattern = INITIAL_COMMIT_MESSAGE
+    with Repo(repo_path) as repo:
+        grep_pattern = FUNCTIONAL_REQUIREMENT_FINISHED_COMMIT_MESSAGE.format(".*")
         grep_pattern = grep_pattern.replace("[", "\\[").replace("]", "\\]")
         commit_sha = repo.git.rev_list(repo.active_branch.name, "--grep", grep_pattern, "-n", "1")
+
         if not commit_sha:
-            raise InvalidGitRepositoryError("Git repository is in an invalid state. Initial commit could not be found.")
+            # Repo was interrupted during the first functionality, fallback to initial commit
+            # and provide only module name
+            grep_pattern = INITIAL_COMMIT_MESSAGE
+            grep_pattern = grep_pattern.replace("[", "\\[").replace("]", "\\]")
+            commit_sha = repo.git.rev_list(repo.active_branch.name, "--grep", grep_pattern, "-n", "1")
+            if not commit_sha:
+                raise InvalidGitRepositoryError(
+                    "Git repository is in an invalid state. Initial commit could not be found."
+                )
+
+            commit_message = repo.commit(commit_sha).message
+            if isinstance(commit_message, bytes):
+                commit_message = commit_message.decode("utf-8")
+
+            match = re.search(r"Module name:\s*(\S+)\n", commit_message)
+            if not match:
+                raise InvalidGitRepositoryError(
+                    "Git repository is in an invalid state. Could not find module name in initial commit."
+                )
+
+            module_name = match.group(1)
+            return module_name, None
 
         commit_message = repo.commit(commit_sha).message
         if isinstance(commit_message, bytes):
             commit_message = commit_message.decode("utf-8")
-
-        match = re.search(r"Module name:\s*(\S+)\n", commit_message)
-        if not match:
-            raise InvalidGitRepositoryError(
-                "Git repository is in an invalid state. Could not find module name in initial commit."
-            )
-
-        module_name = match.group(1)
-        return module_name, None
-
-    commit_message = repo.commit(commit_sha).message
-    if isinstance(commit_message, bytes):
-        commit_message = commit_message.decode("utf-8")
 
     match = re.search(r"FRID\):(\S+) fully implemented", commit_message)
     if not match:

--- a/plain_modules.py
+++ b/plain_modules.py
@@ -283,34 +283,52 @@ class PlainModule:
                 f"  codeplain {self.module_name}{plain_file.PLAIN_SOURCE_FILE_EXTENSION}"
             )
 
-    def _ensure_frid_commit_exists(
+    def _raise_for_missing_frid_commits(
         self,
-        frid: str,
+        previous_frids: list[str],
         first_render_frid: str,
         render_conformance_tests: bool,
     ) -> None:
         """
-        Ensure commit exists for a single FRID in both repositories.
+        Ensure commits exist for every previous FRID in both repositories.
+
+        Each repository is asked once for the whole list rather than once per FRID, and the
+        first FRID that is missing anywhere decides the error, in the order given.
 
         Args:
-            frid: The FRID to check
+            previous_frids: The FRIDs that should already have been rendered
             first_render_frid: The first FRID in the render range (for error messages)
             render_conformance_tests: Whether to check for conformance tests
 
         Raises:
-            MissingPreviousFridCommitsError: If the commit is missing
+            MissingPreviousFunctionalitiesError: If any commit is missing
         """
-        # Check in build folder
-        if not git_utils.has_commit_for_frid(self.module_build_folder, frid, self.module_name):
-            raise MissingPreviousFunctionalitiesError(
-                f"Cannot start rendering from functionality {first_render_frid} for module '{self.module_name}' because the implementation of the previous functionality ({frid}) hasn't been completed yet.\n\n"
-                f"To fix this, please render the missing functionality ({frid}) first by running:\n"
-                f"  codeplain {self.module_name}{plain_file.PLAIN_SOURCE_FILE_EXTENSION} --render-from {frid}"
-            )
-
-        # Check in conformance tests folder (only if conformance tests are enabled)
+        missing_in_build = set(
+            git_utils.frids_missing_commits(self.module_build_folder, previous_frids, self.module_name)
+        )
+        missing_in_tests = set()
         if render_conformance_tests:
-            if not git_utils.has_commit_for_frid(self.module_conformance_tests_folder, frid, self.module_name):
+            try:
+                missing_in_tests = set(
+                    git_utils.frids_missing_commits(
+                        self.module_conformance_tests_folder, previous_frids, self.module_name
+                    )
+                )
+            except Exception:
+                # A broken tests repo must not mask the actionable build-repo error below;
+                # with nothing missing in the build repo it is a real failure and propagates.
+                if not missing_in_build:
+                    raise
+
+        for frid in previous_frids:
+            if frid in missing_in_build:
+                raise MissingPreviousFunctionalitiesError(
+                    f"Cannot start rendering from functionality {first_render_frid} for module '{self.module_name}' because the implementation of the previous functionality ({frid}) hasn't been completed yet.\n\n"
+                    f"To fix this, please render the missing functionality ({frid}) first by running:\n"
+                    f"  codeplain {self.module_name}{plain_file.PLAIN_SOURCE_FILE_EXTENSION} --render-from {frid}"
+                )
+
+            if frid in missing_in_tests:
                 raise MissingPreviousFunctionalitiesError(
                     f"Cannot start rendering from functionality {first_render_frid} for module '{self.module_name}' because the conformance tests for the previous functionality ({frid}) haven't been completed yet.\n\n"
                     f"To fix this, please render the missing functionality ({frid}) first by running:\n"
@@ -342,8 +360,7 @@ class PlainModule:
         self._ensure_module_folders_exist(first_render_frid, render_conformance_tests)
 
         # Verify commits exist for all previous FRIDs
-        for prev_frid in previous_frids:
-            self._ensure_frid_commit_exists(prev_frid, first_render_frid, render_conformance_tests)
+        self._raise_for_missing_frid_commits(previous_frids, first_render_frid, render_conformance_tests)
 
     def get_required_module_by_name(self, module_name: str) -> PlainModule:
         for module in self.all_required_modules:

--- a/plain_modules.py
+++ b/plain_modules.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import shutil
 import tempfile
 import zipfile
 from functools import cached_property
@@ -237,7 +236,7 @@ class PlainModule:
         try:
             _extract_module_archive(self.module_archive_path, scratch_dir)
         except BaseException:
-            shutil.rmtree(scratch_dir, ignore_errors=True)
+            file_utils.delete_folder_best_effort(scratch_dir)
             raise
         self._scratch_dir = scratch_dir
         self._resolved_module_folder = scratch_dir
@@ -265,7 +264,7 @@ class PlainModule:
             _extract_module_archive(self.module_archive_path, staging_dir)
             os.replace(staging_dir, self._default_module_folder)
         except BaseException:
-            shutil.rmtree(staging_dir, ignore_errors=True)
+            file_utils.delete_folder_best_effort(staging_dir)
             raise
 
         os.remove(self.module_archive_path)
@@ -274,7 +273,7 @@ class PlainModule:
 
     def _reset_scratch(self) -> None:
         if self._scratch_dir is not None:
-            shutil.rmtree(self._scratch_dir, ignore_errors=True)
+            file_utils.delete_folder_best_effort(self._scratch_dir)
             self._scratch_dir = None
 
     def cleanup_scratch(self) -> None:

--- a/system_config.py
+++ b/system_config.py
@@ -32,11 +32,10 @@ def _resolve_version() -> str:
         # codeplain checkout's repo, not the caller's working directory
         # (codeplain may be run from anywhere).
         source_dir = os.path.dirname(os.path.abspath(__file__))
-        repo = git.Repo(source_dir, search_parent_directories=True)
-
-        # Highest version tag, regardless of branch ancestry (a dev run may sit
-        # on a feature branch that doesn't descend from the latest release tag).
-        latest_tag = repo.git.tag("--list", "--sort=-v:refname").splitlines()[0]
+        with git.Repo(source_dir, search_parent_directories=True) as repo:
+            # Highest version tag, regardless of branch ancestry (a dev run may sit
+            # on a feature branch that doesn't descend from the latest release tag).
+            latest_tag = repo.git.tag("--list", "--sort=-v:refname").splitlines()[0]
         return latest_tag.lstrip("v")
     except Exception:
         return "0.0.0.dev0"

--- a/tests/test_git_utils.py
+++ b/tests/test_git_utils.py
@@ -1,3 +1,4 @@
+import gc
 import os
 import tempfile
 from pathlib import Path
@@ -28,13 +29,18 @@ def temp_repo():
 
         # Create and commit initial file
         file_path = Path(temp_dir) / "test.txt"
-        file_path.write_text("initial content\nline2\nline3\n")
+        file_path.write_text("initial content\nline2\nline3\n", newline="\n")
 
-        repo = Repo(temp_dir)
-        repo.index.add(["test.txt"])
+        with Repo(temp_dir) as repo:
+            repo.index.add(["test.txt"])
         add_all_files_and_commit(temp_dir, FUNCTIONAL_REQUIREMENT_FINISHED_COMMIT_MESSAGE.format("1.1"))
 
         yield temp_dir
+
+        # Repos opened inside the test body may still hold `git cat-file` children;
+        # on Windows those keep temp_dir undeletable. Collecting here reaps them
+        # (GitPython terminates the children when its objects are finalized).
+        gc.collect()
 
 
 @pytest.fixture
@@ -43,6 +49,7 @@ def empty_repo():
     with tempfile.TemporaryDirectory() as temp_dir:
         init_git_repo(temp_dir)
         yield temp_dir
+        gc.collect()  # same reason as in temp_repo
 
 
 def test_empty_diff(temp_repo):
@@ -57,7 +64,7 @@ def test_single_file_change(temp_repo):
 
     # Modify the file
     file_path = Path(temp_repo) / "test.txt"
-    file_path.write_text("modified content\nline2\nline3\n")
+    file_path.write_text("modified content\nline2\nline3\n", newline="\n")
     repo.index.add(["test.txt"])
     repo.index.commit("Modified test.txt")
 
@@ -83,15 +90,15 @@ def test_multiple_file_changes(temp_repo):
 
     # Create and commit second file
     file2_path = Path(temp_repo) / "file2.txt"
-    file2_path.write_text("file2 initial\nline2\n")
+    file2_path.write_text("file2 initial\nline2\n", newline="\n")
 
     add_all_files_and_commit(temp_repo, "Added file2.txt", None, "1.2")
 
     # Modify both files
     file1_path = Path(temp_repo) / "test.txt"
-    file1_path.write_text("file1 modified\nline2\n")
+    file1_path.write_text("file1 modified\nline2\n", newline="\n")
 
-    file2_path.write_text("file2 modified\nline2")
+    file2_path.write_text("file2 modified\nline2", newline="\n")
 
     # Get diff
     result = diff(temp_repo, "1.1")
@@ -130,23 +137,23 @@ def test_multiple_commits_diff(temp_repo):
 
     # Create and commit second file
     file2_path = Path(temp_repo) / "file2.txt"
-    file2_path.write_text("file2 frid1.1 refactored version\nline2\n")
+    file2_path.write_text("file2 frid1.1 refactored version\nline2\n", newline="\n")
 
     add_all_files_and_commit(temp_repo, REFACTORED_CODE_COMMIT_MESSAGE.format("1.1"), None, "1.1")
     add_all_files_and_commit(temp_repo, FUNCTIONAL_REQUIREMENT_FINISHED_COMMIT_MESSAGE.format("1.1"), None, "1.1")
 
-    file1_path.write_text("file1 frid1.2 version\nline2\n")
-    file2_path.write_text("file2 frid1.2 version\nline2\n")
+    file1_path.write_text("file1 frid1.2 version\nline2\n", newline="\n")
+    file2_path.write_text("file2 frid1.2 version\nline2\n", newline="\n")
 
     add_all_files_and_commit(temp_repo, "implemented frid 1.2", None, "1.2")
 
-    file1_path.write_text("file1 frid1.2 refactored version\nline2\n")
+    file1_path.write_text("file1 frid1.2 refactored version\nline2\n", newline="\n")
 
     add_all_files_and_commit(temp_repo, REFACTORED_CODE_COMMIT_MESSAGE.format("1.2"), None, "1.2")
     add_all_files_and_commit(temp_repo, FUNCTIONAL_REQUIREMENT_FINISHED_COMMIT_MESSAGE.format("1.2"), None, "1.2")
 
     file3_path = Path(temp_repo) / "file3.txt"
-    file3_path.write_text("file3 frid1.2 new file\nline2\n")
+    file3_path.write_text("file3 frid1.2 new file\nline2\n", newline="\n")
 
     # Get diff
     result = diff(temp_repo, "1.1")
@@ -192,12 +199,12 @@ def test_diff_without_previous_frid_and_no_base_folder(empty_repo):
     """Test diff without previous frid and no base folder."""
     # Create a new file without committing
     file_path = Path(empty_repo) / "new.txt"
-    file_path.write_text("new file content\nline2\n")
+    file_path.write_text("new file content\nline2\n", newline="\n")
     add_all_files_and_commit(empty_repo, "First commit")
 
     # create one more file
     file_path = Path(empty_repo) / "new2.txt"
-    file_path.write_text("new file content\nline2\n")
+    file_path.write_text("new file content\nline2\n", newline="\n")
 
     # Get diff
     result = diff(empty_repo)
@@ -227,11 +234,11 @@ def test_diff_without_previous_frid_and_base_folder(temp_repo):
     """Test diff without previous frid and base folder."""
     # Create a commit for the base folder
     file_path = Path(temp_repo) / "new.txt"
-    file_path.write_text("base folder content\nline2\n")
+    file_path.write_text("base folder content\nline2\n", newline="\n")
     add_all_files_and_commit(temp_repo, BASE_FOLDER_COMMIT_MESSAGE)
 
     # update the file
-    file_path.write_text("updated base folder content\nline2\n")
+    file_path.write_text("updated base folder content\nline2\n", newline="\n")
 
     # Get diff
     result = diff(temp_repo)
@@ -254,7 +261,7 @@ def test_new_file(temp_repo):
 
     # Create a new file without committing
     file_path = Path(temp_repo) / "new.txt"
-    file_path.write_text("new file content\nline2\n")
+    file_path.write_text("new file content\nline2\n", newline="\n")
 
     # Get diff
     result = diff(temp_repo, "1.1")
@@ -310,9 +317,9 @@ def test_add_all_files_and_commit(temp_repo):
     """Test adding all files and committing them."""
     # Create some test files
     file1_path = Path(temp_repo) / "file1.txt"
-    file1_path.write_text("content1")
+    file1_path.write_text("content1", newline="\n")
     file2_path = Path(temp_repo) / "file2.txt"
-    file2_path.write_text("content2")
+    file2_path.write_text("content2", newline="\n")
 
     # Add and commit files
     repo = add_all_files_and_commit(temp_repo, "Test commit", None, "FR123", "render-id")
@@ -332,7 +339,7 @@ def test_add_all_files_and_commit(temp_repo):
     assert "file1.txt" in tree
     assert "file2.txt" in tree
 
-    file2_path.write_text("content2 modified")
+    file2_path.write_text("content2 modified", newline="\n")
     repo = add_all_files_and_commit(temp_repo, "Commit changes on existing file", None, "FR4")
     commits = list(repo.iter_commits())
     assert len(commits) == 4
@@ -348,11 +355,11 @@ def test_revert_changes(temp_repo):
     """Test reverting changes in the repository."""
     # Create and commit initial file
     file_path = Path(temp_repo) / "test.txt"
-    file_path.write_text("initial content")
+    file_path.write_text("initial content", newline="\n")
     repo = add_all_files_and_commit(temp_repo, "Initial commit", None, "FR123")
 
     # Modify the file
-    file_path.write_text("modified content")
+    file_path.write_text("modified content", newline="\n")
 
     # Verify the file was modified
     assert file_path.read_text() == "modified content"
@@ -371,19 +378,19 @@ def test_revert_to_commit_with_frid(temp_repo):
     """Test reverting to a specific commit with FRID."""
     # Create and commit first version
     file_path = Path(temp_repo) / "test.txt"
-    file_path.write_text("version 1")
+    file_path.write_text("version 1", newline="\n")
     repo = add_all_files_and_commit(
         temp_repo, FUNCTIONAL_REQUIREMENT_FINISHED_COMMIT_MESSAGE.format("FR123"), None, "FR123"
     )
 
     # Create and commit second version
-    file_path.write_text("version 2")
+    file_path.write_text("version 2", newline="\n")
     repo = add_all_files_and_commit(
         temp_repo, FUNCTIONAL_REQUIREMENT_FINISHED_COMMIT_MESSAGE.format("FR456"), None, "FR456"
     )
 
     # Create and commit third version
-    file_path.write_text("version 3")
+    file_path.write_text("version 3", newline="\n")
     repo = add_all_files_and_commit(
         temp_repo, FUNCTIONAL_REQUIREMENT_FINISHED_COMMIT_MESSAGE.format("FR789"), None, "FR789"
     )
@@ -407,11 +414,11 @@ def test_revert_to_commit_with_frid_and_base_folder(temp_repo):
     """Test reverting to base folder."""
     # Create a commit for the base folder
     file_path = Path(temp_repo) / "new.txt"
-    file_path.write_text("base folder content\nline1\n")
+    file_path.write_text("base folder content\nline1\n", newline="\n")
     add_all_files_and_commit(temp_repo, BASE_FOLDER_COMMIT_MESSAGE)
 
     # create another commit
-    file_path.write_text("changed file content\nline2\n")
+    file_path.write_text("changed file content\nline2\n", newline="\n")
     add_all_files_and_commit(temp_repo, "Another commit")
 
     # revert to base folder
@@ -425,7 +432,7 @@ def test_revert_to_base_folder_no_commit(temp_repo):
     """Test reverting to base folder."""
     # Create a commit for the base folder
     file_path = Path(temp_repo) / "new.txt"
-    file_path.write_text("some content\n")
+    file_path.write_text("some content\n", newline="\n")
     add_all_files_and_commit(temp_repo, "FRID", 123)
 
     # revert initial commit
@@ -452,7 +459,7 @@ def test_get_last_finished_frid_empty_repo(empty_repo):
 def test_get_last_finished_frid_returns_latest(empty_repo):
     """Return the module name and frid from the most recent finished-frid commit."""
     file_path = Path(empty_repo) / "a.txt"
-    file_path.write_text("v1")
+    file_path.write_text("v1", newline="\n")
     add_all_files_and_commit(
         empty_repo,
         FUNCTIONAL_REQUIREMENT_FINISHED_COMMIT_MESSAGE.format("1"),
@@ -460,7 +467,7 @@ def test_get_last_finished_frid_returns_latest(empty_repo):
         frid="1",
     )
 
-    file_path.write_text("v2")
+    file_path.write_text("v2", newline="\n")
     add_all_files_and_commit(
         empty_repo,
         FUNCTIONAL_REQUIREMENT_FINISHED_COMMIT_MESSAGE.format("2"),
@@ -474,7 +481,7 @@ def test_get_last_finished_frid_returns_latest(empty_repo):
 def test_get_last_finished_frid_ignores_non_finished_commits(empty_repo):
     """Commits that aren't finished-frid checkpoints must be skipped."""
     file_path = Path(empty_repo) / "a.txt"
-    file_path.write_text("v1")
+    file_path.write_text("v1", newline="\n")
     add_all_files_and_commit(
         empty_repo,
         FUNCTIONAL_REQUIREMENT_FINISHED_COMMIT_MESSAGE.format("1"),
@@ -483,7 +490,7 @@ def test_get_last_finished_frid_ignores_non_finished_commits(empty_repo):
     )
 
     # A refactor commit (not a finished-frid checkpoint) comes after.
-    file_path.write_text("v2")
+    file_path.write_text("v2", newline="\n")
     add_all_files_and_commit(
         empty_repo,
         REFACTORED_CODE_COMMIT_MESSAGE.format("2"),
@@ -498,7 +505,7 @@ def test_get_last_finished_frid_ignores_non_finished_commits(empty_repo):
 def test_get_last_finished_frid_without_module_name(empty_repo):
     """Raise InvalidGitRepositoryError when the finished commit omits the module name line."""
     file_path = Path(empty_repo) / "a.txt"
-    file_path.write_text("v1")
+    file_path.write_text("v1", newline="\n")
     add_all_files_and_commit(
         empty_repo,
         FUNCTIONAL_REQUIREMENT_FINISHED_COMMIT_MESSAGE.format("7"),

--- a/tests/test_path_resolution.py
+++ b/tests/test_path_resolution.py
@@ -36,13 +36,17 @@ def test_dotdot_segments_are_normalized():
 
 
 def test_leading_tilde_is_expanded(monkeypatch):
+    # os.path.expanduser reads HOME on POSIX and USERPROFILE on Windows.
     monkeypatch.setenv("HOME", "/home/alice")
+    monkeypatch.setenv("USERPROFILE", "/home/alice")
     result = resolve_path("~/scripts/run.sh", "cli", cwd=CWD, config_dir=CONFIG_DIR, spec_dir=SPEC_DIR)
     assert result == os.path.normpath("/home/alice/scripts/run.sh")
 
 
 def test_tilde_expansion_applies_regardless_of_source(monkeypatch):
+    # os.path.expanduser reads HOME on POSIX and USERPROFILE on Windows.
     monkeypatch.setenv("HOME", "/home/alice")
+    monkeypatch.setenv("USERPROFILE", "/home/alice")
     for source in ("cli", "config", "default"):
         result = resolve_path("~/x", source, cwd=CWD, config_dir=CONFIG_DIR, spec_dir=SPEC_DIR)
         assert result == os.path.normpath("/home/alice/x")

--- a/tests/test_plain_modules.py
+++ b/tests/test_plain_modules.py
@@ -7,7 +7,6 @@ These tests build real ``PlainModule`` instances from fixtures in
 
 import json
 import os
-import shutil
 import sys
 import tempfile
 import zipfile
@@ -16,6 +15,7 @@ from pathlib import Path
 import pytest
 
 from change_detection import determine_partial_render_start
+from file_utils import delete_folder
 from git_utils import FUNCTIONAL_REQUIREMENT_FINISHED_COMMIT_MESSAGE, add_all_files_and_commit, init_git_repo
 from plain2code_exceptions import InvalidModuleArchiveError, ModuleDoesNotExistError
 from plain_modules import MODULE_METADATA_FILENAME, PlainModule
@@ -404,7 +404,7 @@ def _archive_module(module: PlainModule) -> str:
     """Turn an on-disk module into an archive-only module: zip it, then remove the folder."""
     archive_path = module.module_archive_path
     _zip_module_flat(module.module_folder, archive_path)
-    shutil.rmtree(module.module_folder)
+    delete_folder(module.module_folder)
     return archive_path
 
 

--- a/tests/test_plain_modules.py
+++ b/tests/test_plain_modules.py
@@ -527,3 +527,38 @@ def test_reconcile_metadata_with_git_no_metadata_is_noop(solo_module):
     solo_module.reconcile_metadata_with_git()
 
     assert solo_module.load_module_metadata() is None
+
+
+# --------------------------------------------------------------------------
+# _raise_for_missing_frid_commits
+# --------------------------------------------------------------------------
+
+
+def test_a_broken_tests_repo_does_not_mask_the_missing_build_commit_error(solo_module, monkeypatch):
+    """The actionable --render-from guidance wins over a raw failure from the tests repo."""
+    import git_utils
+    from plain2code_exceptions import MissingPreviousFunctionalitiesError
+
+    def fake_missing(folder, frids, module_name):
+        if folder == solo_module.module_build_folder:
+            return ["1"]
+        raise RuntimeError("the conformance tests repository is broken")
+
+    monkeypatch.setattr(git_utils, "frids_missing_commits", fake_missing)
+
+    with pytest.raises(MissingPreviousFunctionalitiesError):
+        solo_module._raise_for_missing_frid_commits(["1"], "2", render_conformance_tests=True)
+
+
+def test_a_broken_tests_repo_with_a_healthy_build_repo_still_fails(solo_module, monkeypatch):
+    import git_utils
+
+    def fake_missing(folder, frids, module_name):
+        if folder == solo_module.module_build_folder:
+            return []
+        raise RuntimeError("the conformance tests repository is broken")
+
+    monkeypatch.setattr(git_utils, "frids_missing_commits", fake_missing)
+
+    with pytest.raises(RuntimeError, match="conformance tests repository"):
+        solo_module._raise_for_missing_frid_commits(["1"], "2", render_conformance_tests=True)

--- a/tests/test_plain_modules.py
+++ b/tests/test_plain_modules.py
@@ -7,6 +7,7 @@ These tests build real ``PlainModule`` instances from fixtures in
 
 import json
 import os
+import sys
 import tempfile
 from pathlib import Path
 

--- a/tests/test_prepare_repositories_layout.py
+++ b/tests/test_prepare_repositories_layout.py
@@ -10,7 +10,6 @@ Each module renders into a single tree under the build folder:
 
 import json
 import os
-import shutil
 import tempfile
 import zipfile
 from pathlib import Path
@@ -18,6 +17,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from file_utils import delete_folder
 from git_utils import FUNCTIONAL_REQUIREMENT_FINISHED_COMMIT_MESSAGE, add_all_files_and_commit, init_git_repo
 from partial_rendering import archive_missing_conformance_tests, get_plain_module_render_state, get_render_choices
 from plain_modules import PlainModule
@@ -74,7 +74,7 @@ def _archive_module(module: PlainModule) -> None:
             for name in files:
                 full = os.path.join(root, name)
                 zf.write(full, os.path.relpath(full, module.module_folder))
-    shutil.rmtree(module.module_folder)
+    delete_folder(module.module_folder)
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
The test suite only ever ran on Linux, so nothing stopped a change that works on the maintainers' machines from breaking either of the other two supported platforms.<br><br>Create the macOS and Windows jobs.<br>Fixed:

* **Close GitPython repositories after use.** Each `Repo` keeps a persistent `git cat-file` child reaped only by `close()`. On Windows a live child holds the repository directory open, so a repo under a temp directory cannot be torn down — which is what the `win32` skips in the git tests were avoiding.
* **Batch the missing-commit check per repository.** It ran once per functionality per repo, and `close()` runs `gc.collect()` twice on Windows. Also fixes the report order: an unreadable tests repo used to mask the actionable build-repo error.
* **Add the macOS and Windows CI** e2e **test** **matrix**, plus per-platform mypy.

Windows runners default to PowerShell, where a failing native command does not stop the rest of a multi-command `run` block — so each step runs a single command, or a step could report success after its first command had already failed.