### PR TITLE
Instrument the fix loops

### DIFF
--- a/cli_output/render_summary.py
+++ b/cli_output/render_summary.py
@@ -15,6 +15,20 @@ logger = logging.getLogger(plain2code_logger.LOGGER_NAME)
 RENDER_TRAILER_PREFIX = "[render-trailer]"
 
 
+def render_outcome(run_state: RunState, error_message: Optional[str]) -> str:
+    """What the render did, for the banner and the trailer alike.
+
+    A reason recorded on the way out overrides the success flag. The flag is set per
+    module, so an earlier module's success can still be standing while the process exits
+    on an error - which read as a completed render that produced nothing.
+    """
+    if run_state.render_succeeded and not error_message:
+        return "completed"
+    if run_state.render_cancelled:
+        return "cancelled"
+    return "failed"
+
+
 def print_exit_summary(
     run_state: RunState,
     spec_filename: str,
@@ -23,7 +37,7 @@ def print_exit_summary(
     """Print render outcome after the TUI exits (terminal restored)."""
     console.quiet = False
 
-    if run_state.render_succeeded:
+    if render_outcome(run_state, error_message) == "completed":
         msg = "\n[#79FC96]✓ rendering completed\n\n"
     elif run_state.render_cancelled:
         msg = "\n[#FFFFFF]— rendering canceled\n\n"
@@ -59,12 +73,7 @@ def log_render_trailer(
     the render did, and because it is written on every exit path a log *without* a
     trailer is itself evidence that the file was truncated.
     """
-    if run_state.render_succeeded:
-        outcome = "completed"
-    elif run_state.render_cancelled:
-        outcome = "cancelled"
-    else:
-        outcome = "failed"
+    outcome = render_outcome(run_state, error_message)
 
     # Both times: an action that raises never reaches the render's own terminal accounting,
     # so the banked figure is stale on the paths this trailer exists to describe, and the

--- a/cli_output/render_summary.py
+++ b/cli_output/render_summary.py
@@ -1,10 +1,18 @@
 """Render completion summary display."""
 
+import logging
 from typing import Optional
 
+import plain2code_logger
 from plain2code_console import console
 from plain2code_state import RunState
 from usage_summary import format_usage_summary
+
+logger = logging.getLogger(plain2code_logger.LOGGER_NAME)
+
+# Marks the last line of a render's log file. Greppable on purpose: these logs are read
+# by tooling before they are read by a person.
+RENDER_TRAILER_PREFIX = "[render-trailer]"
 
 
 def print_exit_summary(
@@ -27,6 +35,56 @@ def print_exit_summary(
     msg += format_usage_summary(run_state.rendered_functionalities, run_state.render_time_accumulated) + "\n"
     console.print(msg)
 
-    if not run_state.render_succeeded and error_message:
+    # Reported whenever there is one. A render can finish its functionalities and still
+    # raise on the way out — publishing the build, for instance — and that combination
+    # used to print the success banner and swallow the reason entirely, leaving a caller
+    # with a tick mark and a non-zero exit code.
+    if error_message:
         console.error(error_message)
     console.quiet = True
+
+    log_render_trailer(run_state, spec_filename, error_message)
+
+
+def log_render_trailer(
+    run_state: RunState,
+    spec_filename: str,
+    error_message: Optional[str] = None,
+) -> None:
+    """Writes the render's outcome to the log file, as its last line.
+
+    The summary above reaches the terminal through Rich, which never touches logging, so
+    a captured `codeplain.log` used to stop at whatever happened to be logged last —
+    indistinguishable from a process that died silently. This ends every log with what
+    the render did, and because it is written on every exit path a log *without* a
+    trailer is itself evidence that the file was truncated.
+    """
+    if run_state.render_succeeded:
+        outcome = "completed"
+    elif run_state.render_cancelled:
+        outcome = "cancelled"
+    else:
+        outcome = "failed"
+
+    # Both times: an action that raises never reaches the render's own terminal accounting,
+    # so the banked figure is stale on the paths this trailer exists to describe, and the
+    # live one covers them without changing what render_time_s has always meant.
+    trailer = (
+        f"{RENDER_TRAILER_PREFIX} outcome={outcome} "
+        f"render_id={run_state.render_id} "
+        f"functionalities={run_state.rendered_functionalities} "
+        f"render_time_s={run_state.render_time_accumulated} "
+        f"render_time_live_s={run_state.get_live_render_time()} "
+        f"generated_code={run_state.render_generated_code_path or '-'} "
+        f"spec={spec_filename}"
+    )
+    if error_message:
+        # On the same record, and quoted: a second record would leave the outcome one line
+        # short of the end, and exception messages routinely carry newlines.
+        trailer += f" error={error_message!r}"
+    logger.info(trailer)
+
+    # The process may exit immediately after this; an unflushed trailer would defeat the
+    # purpose of writing one.
+    for handler in logger.handlers:
+        handler.flush()

--- a/codeplain_REST_api.py
+++ b/codeplain_REST_api.py
@@ -19,6 +19,7 @@ RETRY_ERROR_CODES = [
 ERROR_CODE_EXCEPTIONS = {
     "FunctionalRequirementTooComplex": plain2code_exceptions.FunctionalRequirementTooComplex,
     "ConflictingRequirements": plain2code_exceptions.ConflictingRequirements,
+    "ConformanceTestsFixExhausted": plain2code_exceptions.ConformanceTestsFixExhausted,
     "RenderingCreditBalanceTooLow": plain2code_exceptions.RenderingCreditBalanceTooLow,
     "LLMInternalError": plain2code_exceptions.LLMInternalError,
     "MissingResource": plain2code_exceptions.MissingResource,

--- a/codeplain_REST_api.py
+++ b/codeplain_REST_api.py
@@ -112,8 +112,7 @@ class CodeplainAPI:
             raise plain2code_exceptions.plain_syntax_error(message or "Unknown error")
         if error_code == "InternalServerError":
             raise plain2code_exceptions.InternalServerError(
-                "Internal server error.\n\n"
-                "Please report the error to support@codeplain.ai with the attached .log file."
+                "Internal server error. The render log records the render ID and what the render was doing."
             )
         exception_class = ERROR_CODE_EXCEPTIONS[error_code]
         raise exception_class(message)

--- a/codeplain_REST_api.py
+++ b/codeplain_REST_api.py
@@ -143,7 +143,11 @@ class CodeplainAPI:
                     self.console.debug(f"Failed to decode JSON response: {e}. Response text: {response.text}")
                     raise Exception(f"Error rendering plain code: Failed to decode API response ({e}).\n") from e
 
-                if response.status_code == requests.codes.bad_request and "error_code" in response_json:
+                # Any status the server declines on, not only 400. The server returns
+                # error_code with 500 as well, and reading it only on 400 meant those
+                # reached the user as the raw "500 Server Error for url: ..." rather than
+                # the message the code was paired with.
+                if not response.ok and "error_code" in response_json:
                     self._raise_for_error_code(response_json)
 
                 response.raise_for_status()

--- a/plain2code.py
+++ b/plain2code.py
@@ -24,6 +24,7 @@ from plain2code_console import console
 from plain2code_events import RenderFailed
 from plain2code_exceptions import (
     ConflictingRequirements,
+    ConformanceTestsFixExhausted,
     GitNotInstalledError,
     ImportedModuleWithFunctionalitiesError,
     InvalidAPIKey,
@@ -73,6 +74,7 @@ EXPECTED_EXCEPTIONS = (
     InvalidAPIKey,
     OutdatedClientVersion,
     ConflictingRequirements,
+    ConformanceTestsFixExhausted,
     RenderingCreditBalanceTooLow,
     NetworkConnectionError,
     ModuleDoesNotExistError,

--- a/plain2code.py
+++ b/plain2code.py
@@ -411,14 +411,16 @@ def main():  # noqa: C901
             if not isinstance(e, EXPECTED_EXCEPTIONS):
                 exc_info = sys.exc_info()
     finally:
-        if exc_info:
-            dump_crash_logs(args, run_state)
-            capture_crash(exc_info, run_state, args)
+        # Writes the trailer, so it runs before the crash dump: a log dumped without one
+        # is indistinguishable from a truncated one.
         print_exit_summary(
             run_state,
             args.filename,
             error_message=error_message,
         )
+        if exc_info:
+            dump_crash_logs(args, run_state)
+            capture_crash(exc_info, run_state, args)
 
     if args.headless and (exc_info is not None or not run_state.render_succeeded):
         sys.exit(1)

--- a/plain2code.py
+++ b/plain2code.py
@@ -192,6 +192,25 @@ def warn_if_acceptance_tests_without_conformance_script(plain_module, args) -> N
     )
 
 
+def _render_recording_outcome(module_renderer, run_state: RunState) -> Exception | None:
+    """Runs the render and records how it ended, returning the failure if there was one.
+
+    The outcome is recorded per module, so a render that fails after an earlier module has
+    completed is still holding that module's success. Both the render trailer and the
+    headless exit code read that flag, and the exit code is 0 when the failure is one of
+    EXPECTED_EXCEPTIONS - so a caller that skips this reports a failed render as a
+    successful one.
+    """
+    try:
+        module_renderer.render_module()
+    except RenderCancelledError:
+        run_state.set_render_cancelled()  # The TUI is already closed, nothing to report.
+    except Exception as error:
+        run_state.set_render_succeeded(False)
+        return error
+    return None
+
+
 def render(  # noqa: C901
     plain_module: plain_modules.PlainModule,
     args,
@@ -285,21 +304,16 @@ def render(  # noqa: C901
     render_error: list[Exception] = []
 
     def run_render():
-        try:
-            module_renderer.render_module()
-        except RenderCancelledError:
-            run_state.set_render_cancelled()  # TUI already closed, nothing to report
-        except Exception as e:
-            run_state.set_render_succeeded(False)
-            render_error.append(e)
-            event_bus.publish(RenderFailed(error_message=str(e)))
+        error = _render_recording_outcome(module_renderer, run_state)
+        if error is not None:
+            render_error.append(error)
+            event_bus.publish(RenderFailed(error_message=str(error)))
 
     if args.headless:
         console.info(f"Render started. Render ID: {run_state.render_id}")
-        try:
-            module_renderer.render_module()
-        except RenderCancelledError:
-            run_state.set_render_cancelled()
+        error = _render_recording_outcome(module_renderer, run_state)
+        if error is not None:
+            raise error
         return
     else:
         render_thread = threading.Thread(target=run_render, daemon=True)

--- a/plain2code_exceptions.py
+++ b/plain2code_exceptions.py
@@ -13,6 +13,10 @@ class RenderingCreditBalanceTooLow(Exception):
     pass
 
 
+class ConformanceTestsFixExhausted(Exception):
+    """The server's conformance-fix loop spent its attempt budget on one functionality."""
+
+
 class LLMInternalError(Exception):
     pass
 

--- a/render_machine/actions/exit_with_error.py
+++ b/render_machine/actions/exit_with_error.py
@@ -12,6 +12,12 @@ class ExitWithError(BaseAction):
     def execute(self, render_context: RenderContext, previous_action_payload: Any | None):
         console.error(self._error_message(render_context, previous_action_payload))
 
+        # The FRID that failed is the one whose fix-loop counts matter most, and it never
+        # reaches FinishFunctionalRequirement — so the whole render's counts are reported
+        # here rather than lost with it.
+        for summary in render_context.fix_loop_metrics.render_summary():
+            console.info(summary)
+
         render_context.codeplain_api.fail_functional_requirement(
             render_context.frid_context.frid,
             module_name=render_context.module_name,

--- a/render_machine/actions/exit_with_error.py
+++ b/render_machine/actions/exit_with_error.py
@@ -10,7 +10,7 @@ class ExitWithError(BaseAction):
     SUCCESSFUL_OUTCOME = "error_handled"
 
     def execute(self, render_context: RenderContext, previous_action_payload: Any | None):
-        console.error(previous_action_payload)
+        console.error(self._error_message(render_context, previous_action_payload))
 
         render_context.codeplain_api.fail_functional_requirement(
             render_context.frid_context.frid,
@@ -33,3 +33,22 @@ class ExitWithError(BaseAction):
                 message=render_context.last_error_message or "Unknown error",
             ).to_payload(),
         )
+
+    @staticmethod
+    def _error_message(render_context: RenderContext, previous_action_payload: Any | None) -> str:
+        """What the user is told the render stopped for.
+
+        Actions reach this state by three routes: some hand over an encoded RenderError
+        payload, some a plain string, and some nothing at all. Printing the payload as it
+        arrives showed a raw dict for the first and the word "None" for the last, so the
+        reason is unwrapped here and falls back to the same message the returned payload
+        carries.
+        """
+        if isinstance(previous_action_payload, dict):
+            error = previous_action_payload.get("error")
+            if isinstance(error, dict) and error.get("message"):
+                return error["message"]
+        elif previous_action_payload:
+            return str(previous_action_payload)
+
+        return render_context.last_error_message or "Unknown error"

--- a/render_machine/actions/finish_functional_requirement.py
+++ b/render_machine/actions/finish_functional_requirement.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from render_machine.actions.commit_implementation_code_changes import CommitImplementationCodeChanges
+from render_machine.fix_loop_metrics import report_frid_fix_loop_summary
 from render_machine.render_context import RenderContext
 
 
@@ -8,6 +9,8 @@ class FinishFunctionalRequirement(CommitImplementationCodeChanges):
     SUCCESSFUL_OUTCOME = "functional_requirement_finished"
 
     def execute(self, render_context: RenderContext, previous_action_payload: Any | None):
+        report_frid_fix_loop_summary(render_context, render_context.frid_context.frid)
+
         render_context.plain_module.update_frid_in_module_metadata(render_context.frid_context.frid)
 
         super().execute(render_context, previous_action_payload)

--- a/render_machine/actions/fix_conformance_test.py
+++ b/render_machine/actions/fix_conformance_test.py
@@ -9,7 +9,7 @@ from plain2code_exceptions import InternalClientError
 from render_machine.actions.base_action import BaseAction
 from render_machine.implementation_code_helpers import ImplementationCodeHelpers
 from render_machine.render_context import RenderContext
-from render_machine.render_types import RenderError, TestExecutionPhase
+from render_machine.render_types import FIX_LOOP_EXHAUSTED_HINT, RenderError, TestExecutionPhase
 
 MAX_CONFORMANCE_TEST_FIX_ATTEMPTS = 20
 MAX_CONFORMANCE_TEST_RERENDER_ATTEMPTS = 1
@@ -32,11 +32,20 @@ class FixConformanceTest(BaseAction):
 
         if ctx.fix_attempts >= MAX_CONFORMANCE_TEST_FIX_ATTEMPTS:
             if ctx.conformance_tests_render_attempts >= MAX_CONFORMANCE_TEST_RERENDER_ATTEMPTS:
-                error_msg = f"The renderer was unable to produce an implementation that passes conformance tests for functionality '{render_context.frid_context.frid}' after many attempts. Please review and rewrite the specification. (Render ID: {render_context.run_state.render_id})"
+                error_msg = (
+                    f"Rendering stopped: the conformance tests for functionality "
+                    f"'{render_context.frid_context.frid}' still failed after "
+                    f"{MAX_CONFORMANCE_TEST_FIX_ATTEMPTS} attempts at fixing them. {FIX_LOOP_EXHAUSTED_HINT} "
+                    f"(Render ID: {render_context.run_state.render_id})"
+                )
                 render_context.last_error_message = error_msg
                 return (
                     self.LIMIT_EXCEEDED_OUTCOME,
-                    RenderError.encode(message=error_msg).to_payload(),
+                    RenderError.encode(
+                        message=error_msg,
+                        error_type="CONFORMANCE_TESTS_FIX_EXHAUSTED",
+                        frid=render_context.frid_context.frid,
+                    ).to_payload(),
                 )
             else:
                 ctx.regenerating_conformance_tests = True

--- a/render_machine/actions/refactor_code.py
+++ b/render_machine/actions/refactor_code.py
@@ -22,7 +22,7 @@ class RefactorCode(BaseAction):
         render_context.frid_context.refactoring_iteration += 1
 
         if render_context.frid_context.refactoring_iteration >= MAX_REFACTORING_ITERATIONS:
-            error_message = "Refactoring iterations limit of {MAX_REFACTORING_ITERATIONS} reached for functionality {render_context.frid_context.frid}."
+            error_message = f"Refactoring iterations limit of {MAX_REFACTORING_ITERATIONS} reached for functionality {render_context.frid_context.frid}."
             render_context.last_error_message = error_message
 
             return (

--- a/render_machine/actions/render_functional_requirement.py
+++ b/render_machine/actions/render_functional_requirement.py
@@ -8,7 +8,7 @@ from plain2code_exceptions import FunctionalRequirementTooComplex
 from render_machine.actions.base_action import BaseAction
 from render_machine.implementation_code_helpers import ImplementationCodeHelpers
 from render_machine.render_context import RenderContext
-from render_machine.render_types import RenderError
+from render_machine.render_types import FIX_LOOP_EXHAUSTED_HINT, RenderError
 
 MAX_CODE_GENERATION_RETRIES = 2
 
@@ -21,9 +21,9 @@ class RenderFunctionalRequirement(BaseAction):
     def execute(self, render_context: RenderContext, _previous_action_payload: Any | None):
         if render_context.frid_context.functional_requirement_render_attempts >= MAX_CODE_GENERATION_RETRIES:
             error_msg = (
-                f"The renderer was unable to produce an implementation whose unit tests pass for functionality "
-                f"'{render_context.frid_context.frid}' after rendering it from scratch {MAX_CODE_GENERATION_RETRIES} "
-                f"times. Please review and rewrite the specification."
+                f"Rendering stopped: the unit tests for functionality '{render_context.frid_context.frid}' still "
+                f"failed after rendering it from scratch {MAX_CODE_GENERATION_RETRIES} times. "
+                f"{FIX_LOOP_EXHAUSTED_HINT}"
             )
             render_context.last_error_message = error_msg
             return (

--- a/render_machine/actions/render_functional_requirement.py
+++ b/render_machine/actions/render_functional_requirement.py
@@ -20,9 +20,20 @@ class RenderFunctionalRequirement(BaseAction):
 
     def execute(self, render_context: RenderContext, _previous_action_payload: Any | None):
         if render_context.frid_context.functional_requirement_render_attempts >= MAX_CODE_GENERATION_RETRIES:
-            error_msg = f"Unittests could not be fixed after rendering the functionality {render_context.frid_context.frid} for the {MAX_CODE_GENERATION_RETRIES} times."
+            error_msg = (
+                f"The renderer was unable to produce an implementation whose unit tests pass for functionality "
+                f"'{render_context.frid_context.frid}' after rendering it from scratch {MAX_CODE_GENERATION_RETRIES} "
+                f"times. Please review and rewrite the specification."
+            )
             render_context.last_error_message = error_msg
-            return self.ITERATION_LIMIT_EXCEEDED_OUTCOME, None
+            return (
+                self.ITERATION_LIMIT_EXCEEDED_OUTCOME,
+                RenderError.encode(
+                    message=error_msg,
+                    error_type="UNIT_TESTS_FIX_EXHAUSTED",
+                    frid=render_context.frid_context.frid,
+                ).to_payload(),
+            )
 
         render_context.frid_context.functional_requirement_render_attempts += 1
 

--- a/render_machine/actions/run_conformance_tests.py
+++ b/render_machine/actions/run_conformance_tests.py
@@ -4,6 +4,7 @@ from typing import Any
 import render_machine.render_utils as render_utils
 from plain2code_console import console
 from render_machine.actions.base_action import BaseAction
+from render_machine.fix_loop_metrics import CONFORMANCE_LOOP, report_fix_loop_attempt
 from render_machine.render_context import RenderContext
 from render_machine.render_types import RenderError
 
@@ -56,6 +57,14 @@ class RunConformanceTests(BaseAction):
 
         render_context.memory_manager.create_conformance_tests_memory(
             render_context, exit_code, conformance_tests_issue
+        )
+
+        report_fix_loop_attempt(
+            render_context,
+            loop=CONFORMANCE_LOOP,
+            frid=render_context.conformance_tests_running_context.current_testing_frid,
+            passed=exit_code == 0,
+            output=conformance_tests_issue,
         )
 
         if exit_code == 0:

--- a/render_machine/actions/run_unit_tests.py
+++ b/render_machine/actions/run_unit_tests.py
@@ -4,6 +4,7 @@ from typing import Any
 import render_machine.render_utils as render_utils
 from plain2code_console import console
 from render_machine.actions.base_action import BaseAction
+from render_machine.fix_loop_metrics import UNIT_LOOP, report_fix_loop_attempt
 from render_machine.render_context import RenderContext
 from render_machine.render_types import RenderError
 
@@ -31,6 +32,15 @@ class RunUnitTests(BaseAction):
 
         render_context.script_execution_history.latest_unit_test_output_path = unittests_temp_log_file_path
         render_context.script_execution_history.should_update_script_outputs = True
+
+        report_fix_loop_attempt(
+            render_context,
+            loop=UNIT_LOOP,
+            frid=render_context.frid_context.frid if render_context.frid_context else None,
+            passed=exit_code == 0,
+            output=unittests_issue,
+        )
+
         if exit_code == 0:
             return self.SUCCESSFUL_OUTCOME, None
 

--- a/render_machine/code_renderer.py
+++ b/render_machine/code_renderer.py
@@ -3,6 +3,7 @@ from copy import deepcopy
 
 from transitions.extensions.diagrams import HierarchicalGraphMachine
 
+from plain2code_console import console
 from plain2code_events import (
     RenderModuleCompleted,
     RenderModuleFailed,
@@ -79,6 +80,8 @@ class CodeRenderer:
                 break
 
             if self.render_context.state == States.RENDER_COMPLETED.value:
+                for summary in self.render_context.fix_loop_metrics.render_summary():
+                    console.info(summary)
                 self.render_context.event_bus.publish(
                     RenderModuleCompleted(module_name=self.render_context.module_name)
                 )

--- a/render_machine/fix_loop_metrics.py
+++ b/render_machine/fix_loop_metrics.py
@@ -1,0 +1,165 @@
+"""Per-FRID accounting for the two fix loops, and detection of a stalled loop.
+
+Both loops - unit tests during implementation, conformance tests afterwards - patch,
+re-run the test script, and repeat until a budget runs out. Neither detects an attempt
+that changed nothing, so a loop can spend its whole budget rewriting the same file
+against the same failure.
+
+Detection: each failure is fingerprinted, and consecutive identical fingerprints are
+counted per loop and FRID. A streak means the loop is re-patching without effect, which
+is worth reporting when it starts rather than when the budget runs out.
+
+Measurement: attempts and failures are counted per (module, FRID, loop), so a render
+reports how many iterations convergence took rather than only whether it gave up.
+Exhaustion is a rare binary event; iterations-to-convergence is a finer signal and says
+something after a single run.
+
+Recording never affects rendering. These are observations.
+"""
+
+import hashlib
+import re
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Set, Tuple
+
+from plain2code_console import console
+
+UNIT_LOOP = "unit"
+CONFORMANCE_LOOP = "conformance"
+
+# Parts of a test script's output that differ between two runs of the very same failure.
+# Left in place, any one of them would make every attempt look novel and hide a stuck
+# loop; over-normalising would do the reverse and merge failures that differ for real, so
+# only demonstrably volatile tokens are erased.
+_VOLATILE_PATTERNS = (
+    # Renderer scratch paths on every supported platform. The directory differs per
+    # platform and the name within it per run, so a repeat would otherwise go unrecognised.
+    re.compile(r"/tmp/[^\s'\"]+"),  # Linux: /tmp/tmpk8flk7f1.script_output
+    re.compile(r"(?:/private)?/var/folders/[^\s'\"]+"),  # macOS: /var/folders/qk/.../T/tmpk8flk7f1
+    re.compile(r"[A-Za-z]:\\[^\s'\"]*?\\Temp\\[^\s'\"]*", re.IGNORECASE),  # Windows: C:\...\AppData\Local\Temp\...
+    re.compile(r"\b0x[0-9a-fA-F]+\b"),  # memory addresses
+    re.compile(r"\b[0-9a-fA-F]{8,}\b"),  # hashes, uuids, run ids
+    re.compile(r"\b\d+(?:\.\d+)?\s*m?s\b"),  # durations: "1335.821531 ms", "22.5s"
+    re.compile(r"duration_ms\s+[\d.]+"),
+)
+
+
+def failure_fingerprint(output: str) -> str:
+    """A stable identity for one failure, insensitive to run-to-run noise."""
+    normalized = output or ""
+    for pattern in _VOLATILE_PATTERNS:
+        normalized = pattern.sub("", normalized)
+    normalized = " ".join(normalized.split())
+    return hashlib.sha1(normalized.encode("utf-8", errors="replace")).hexdigest()[:12]
+
+
+@dataclass
+class _LoopCounters:
+    attempts: int = 0
+    failures: int = 0
+    max_repeat: int = 1
+    last_fingerprint: Optional[str] = None
+    current_repeat: int = 0
+
+
+@dataclass
+class FixLoopMetrics:
+    """One per render. Keyed by (module, frid) so a re-rendered FRID keeps accumulating."""
+
+    _counters: Dict[Tuple[str, str], Dict[str, _LoopCounters]] = field(default_factory=dict)
+    _order: List[Tuple[str, str]] = field(default_factory=list)
+    _summarized: Set[Tuple[str, str]] = field(default_factory=set)
+
+    def record(self, loop: str, module: str, frid: str, passed: bool, output: str) -> Optional[int]:
+        """Records one script run. Returns the streak length when this failure is a
+        repeat of the one before it in the same loop, otherwise None."""
+        key = (module, str(frid))
+        if key not in self._counters:
+            self._counters[key] = {}
+            self._order.append(key)
+        counters = self._counters[key].setdefault(loop, _LoopCounters())
+
+        counters.attempts += 1
+        if passed:
+            counters.last_fingerprint = None
+            counters.current_repeat = 0
+            return None
+
+        counters.failures += 1
+        fingerprint = failure_fingerprint(output)
+        if fingerprint == counters.last_fingerprint:
+            counters.current_repeat += 1
+            counters.max_repeat = max(counters.max_repeat, counters.current_repeat)
+            return counters.current_repeat
+
+        counters.last_fingerprint = fingerprint
+        counters.current_repeat = 1
+        return None
+
+    def frid_summary(self, module: str, frid: str) -> Optional[str]:
+        """One greppable line per FRID, or None if no script ran for it."""
+        counters = self._counters.get((module, str(frid)))
+        if not counters:
+            return None
+
+        parts = [f"[fix-loop] module={module} frid={frid}"]
+        for loop in (UNIT_LOOP, CONFORMANCE_LOOP):
+            if loop in counters:
+                parts.append(
+                    f"{loop}={counters[loop].attempts} "
+                    f"{loop}_failed={counters[loop].failures} "
+                    f"{loop}_max_repeat={counters[loop].max_repeat}"
+                )
+        # Per-loop streaks are what a reader needs, since the two loops stall for
+        # different reasons and warrant different responses. The aggregate stays because
+        # existing tooling reads it.
+        parts.append(f"max_repeat={max(loop.max_repeat for loop in counters.values())}")
+        return " ".join(parts)
+
+    def take_frid_summary(self, module: str, frid: str) -> Optional[str]:
+        """The summary for this FRID, once. A FRID reports as it finishes, so the sweep at
+        the end is for the one that never got there."""
+        key = (module, str(frid))
+        if key in self._summarized:
+            return None
+        summary = self.frid_summary(module, frid)
+        if summary:
+            self._summarized.add(key)
+        return summary
+
+    def render_summary(self) -> List[str]:
+        """Every FRID that has not already reported, in the order it was first reached."""
+        summaries = (self.take_frid_summary(module, frid) for module, frid in self._order)
+        return [summary for summary in summaries if summary]
+
+
+# How many identical failures in a row before the loop is called stalled. Two can happen
+# when a patch legitimately addresses something else first; by three the loop is
+# re-patching against a failure it is not moving.
+REPEATED_FAILURE_WARNING_THRESHOLD = 3
+
+
+def report_fix_loop_attempt(render_context, loop: str, frid: Optional[str], passed: bool, output: str) -> None:
+    """Records one script run and tells the user when the loop stops making progress."""
+    if frid is None:
+        return
+
+    streak = render_context.fix_loop_metrics.record(
+        loop, module=render_context.module_name, frid=frid, passed=passed, output=output
+    )
+
+    if streak is not None and streak >= REPEATED_FAILURE_WARNING_THRESHOLD:
+        console.warning(
+            f"The {loop} tests for functionality {frid} have failed the same way {streak} times in a row. "
+            f"The last {streak - 1} fix attempts changed nothing that the tests can see."
+        )
+
+
+def report_frid_fix_loop_summary(render_context, frid: Optional[str]) -> None:
+    """Emits the per-FRID counts once the FRID is done, successfully or not."""
+    if frid is None:
+        return
+
+    summary = render_context.fix_loop_metrics.take_frid_summary(render_context.module_name, frid)
+    if summary:
+        console.info(summary)

--- a/render_machine/render_context.py
+++ b/render_machine/render_context.py
@@ -13,6 +13,7 @@ from plain2code_state import RunState
 from plain_modules import PlainModule
 from render_machine import triggers
 from render_machine.conformance_tests import CONFORMANCE_TESTS_DEFINITION_FILE_NAME, ConformanceTests
+from render_machine.fix_loop_metrics import FixLoopMetrics
 from render_machine.render_types import (
     AcceptanceTestPhase,
     ConformanceTestsRunningContext,
@@ -95,6 +96,10 @@ class RenderContext:
 
         self.machine = None
         self.last_error_message: str | None = None
+        # Observations only — see render_machine/fix_loop_metrics.py. Deliberately not
+        # part of the snapshot: a rolled-back FRID still consumed the attempts it made,
+        # and hiding them would understate what convergence cost.
+        self.fix_loop_metrics = FixLoopMetrics()
 
     def set_machine(self, machine):
         self.machine = machine

--- a/render_machine/render_types.py
+++ b/render_machine/render_types.py
@@ -148,6 +148,12 @@ class ScriptExecutionHistory:
     should_update_script_outputs: bool = False
 
 
+# Both fix loops end the same way when they run out of attempts, and neither ending tells us
+# the specification is at fault - only that we did not converge. The reason points at the
+# evidence instead of assigning blame.
+FIX_LOOP_EXHAUSTED_HINT = "The render log records what each attempt failed on."
+
+
 @dataclass
 class RenderError:
     """Standardized error format for all render failures."""

--- a/tests/test_exit_with_error.py
+++ b/tests/test_exit_with_error.py
@@ -1,0 +1,65 @@
+"""The operator-facing message on a failed render.
+
+`ExitWithError` prints the payload the failing action handed over, but not every path
+into it supplies one — a render that gave up inside the unit-test fix loop arrives with
+`None`, and the user was shown a bare `ERROR codeplain: None` with no reason. The encoded
+payload already falls back to `last_error_message`; the console line must agree, so the
+message a user sees is never less informative than the one the renderer returns.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from render_machine.actions.exit_with_error import ExitWithError
+from render_machine.render_types import RenderError
+
+
+def render_context(last_error_message=None):
+    context = MagicMock()
+    context.last_error_message = last_error_message
+    context.frid_context.frid = "2"
+    context.run_state.render_id = "render-id"
+    return context
+
+
+def executed_with(payload, last_error_message=None):
+    context = render_context(last_error_message)
+    with patch("render_machine.actions.exit_with_error.console") as console:
+        outcome, encoded = ExitWithError().execute(context, payload)
+    return console.error.call_args[0][0], outcome, encoded
+
+
+def test_the_failing_action_s_own_message_is_shown():
+    shown, outcome, _ = executed_with("Conformance tests could not be fixed.")
+
+    assert shown == "Conformance tests could not be fixed."
+    assert outcome == ExitWithError.SUCCESSFUL_OUTCOME
+
+
+def test_a_missing_payload_falls_back_to_the_last_error_message():
+    shown, _, _ = executed_with(None, last_error_message="The Unit Tests script has failed.")
+
+    assert shown == "The Unit Tests script has failed."
+
+
+def test_with_nothing_to_report_the_user_still_gets_words():
+    shown, _, _ = executed_with(None)
+
+    assert shown == "Unknown error"
+
+
+def test_an_encoded_error_payload_is_unwrapped_to_its_reason():
+    """The conformance-fix-exhausted path arrives as an encoded RenderError, which used
+    to reach the user as a raw dict repr."""
+    payload = RenderError.encode(message="Could not produce an implementation that passes.").to_payload()
+
+    shown, _, _ = executed_with(payload)
+
+    assert shown == "Could not produce an implementation that passes."
+
+
+def test_the_shown_message_matches_the_encoded_one():
+    """Two sources of truth for the same failure would let the log and the returned
+    error disagree about why a render stopped."""
+    shown, _, encoded = executed_with(None, last_error_message="The Unit Tests script has failed.")
+
+    assert shown == encoded["error"]["message"]

--- a/tests/test_fix_loop_metrics.py
+++ b/tests/test_fix_loop_metrics.py
@@ -1,0 +1,180 @@
+"""Tests for the fix-loop instrumentation.
+
+Every render that produced no code was a fix loop spending its whole budget
+re-patching one file against one failure. The loop could not tell it was stuck, and the
+only externally visible outcome was a rare binary "did the render abort" — too coarse to
+compare configurations against. This turns both into observations: a streak counter that
+names a repeated-identical failure while it is happening, and per-FRID attempt counts
+that make convergence a continuous measure.
+
+The fingerprint has to survive the parts of a test-script's output that change on every
+run — temp paths, durations, addresses — while still separating genuinely different
+failures, since both mistakes destroy the signal in opposite directions.
+"""
+
+import pytest
+
+from render_machine.fix_loop_metrics import CONFORMANCE_LOOP, UNIT_LOOP, FixLoopMetrics, failure_fingerprint
+
+
+def test_the_same_failure_fingerprints_the_same():
+    first = "FAILED test_header.py::test_subtitle\nAssertionError: subtitle not shown"
+    second = "FAILED test_header.py::test_subtitle\nAssertionError: subtitle not shown"
+
+    assert failure_fingerprint(first) == failure_fingerprint(second)
+
+
+def test_volatile_noise_does_not_change_the_fingerprint():
+    """Two runs of one failing suite differ in temp path, duration and address."""
+    first = (
+        "Output stored in /tmp/tmpk8flk7f1.script_output\n# duration_ms 1335.821531\nat 0x7f3a2b1c AssertionError: x"
+    )
+    second = "Output stored in /tmp/tmpy0wo02yi.script_output\n# duration_ms 22.5\nat 0x55e1ff90 AssertionError: x"
+
+    assert failure_fingerprint(first) == failure_fingerprint(second)
+
+
+def test_a_different_failure_fingerprints_differently():
+    assert failure_fingerprint("AssertionError: subtitle not shown") != failure_fingerprint(
+        "AssertionError: button not found"
+    )
+
+
+def test_a_first_failure_is_not_a_repeat():
+    metrics = FixLoopMetrics()
+
+    streak = metrics.record(UNIT_LOOP, module="m", frid="1", passed=False, output="boom")
+
+    assert streak is None
+
+
+def test_the_same_failure_twice_reports_a_streak():
+    metrics = FixLoopMetrics()
+
+    metrics.record(UNIT_LOOP, module="m", frid="1", passed=False, output="boom")
+    streak = metrics.record(UNIT_LOOP, module="m", frid="1", passed=False, output="boom")
+
+    assert streak == 2
+
+
+def test_a_different_failure_restarts_the_streak():
+    metrics = FixLoopMetrics()
+
+    metrics.record(UNIT_LOOP, module="m", frid="1", passed=False, output="boom")
+    metrics.record(UNIT_LOOP, module="m", frid="1", passed=False, output="boom")
+    streak = metrics.record(UNIT_LOOP, module="m", frid="1", passed=False, output="different")
+
+    assert streak is None
+
+
+def test_the_two_loops_are_counted_apart():
+    """A unit-test failure must not extend a conformance streak, or vice versa."""
+    metrics = FixLoopMetrics()
+
+    metrics.record(UNIT_LOOP, module="m", frid="1", passed=False, output="boom")
+    streak = metrics.record(CONFORMANCE_LOOP, module="m", frid="1", passed=False, output="boom")
+
+    assert streak is None
+
+
+def test_each_frid_counts_its_own_attempts():
+    metrics = FixLoopMetrics()
+
+    metrics.record(UNIT_LOOP, module="m", frid="1", passed=False, output="a")
+    metrics.record(UNIT_LOOP, module="m", frid="1", passed=True, output="")
+    metrics.record(UNIT_LOOP, module="m", frid="2", passed=True, output="")
+
+    assert (
+        metrics.frid_summary("m", "1")
+        == "[fix-loop] module=m frid=1 unit=2 unit_failed=1 unit_max_repeat=1 max_repeat=1"
+    )
+    assert (
+        metrics.frid_summary("m", "2")
+        == "[fix-loop] module=m frid=2 unit=1 unit_failed=0 unit_max_repeat=1 max_repeat=1"
+    )
+
+
+def test_a_frid_summary_reports_both_loops_and_the_worst_streak():
+    metrics = FixLoopMetrics()
+
+    for _ in range(3):
+        metrics.record(CONFORMANCE_LOOP, module="m", frid="2", passed=False, output="same")
+    metrics.record(UNIT_LOOP, module="m", frid="2", passed=True, output="")
+
+    summary = metrics.frid_summary("m", "2")
+
+    assert "conformance=3" in summary
+    assert "conformance_failed=3" in summary
+    assert "unit=1" in summary
+    assert "max_repeat=3" in summary
+
+
+def test_each_loop_reports_its_own_streak():
+    """The aggregate cannot say which loop wedged, and the two wedge for different
+    reasons: a stuck unit loop means the implementation is not moving, a stuck
+    conformance loop can mean the test script never even ran. Reading a run where the
+    unit loop repeated seven times and conformance only three, the single number says
+    7 and invites the reader to attribute it to conformance."""
+    metrics = FixLoopMetrics()
+    for _ in range(7):
+        metrics.record(UNIT_LOOP, module="m", frid="3", passed=False, output="same unit failure")
+    for _ in range(3):
+        metrics.record(CONFORMANCE_LOOP, module="m", frid="3", passed=False, output="same conformance failure")
+
+    summary = metrics.frid_summary("m", "3")
+
+    assert "unit_max_repeat=7" in summary
+    assert "conformance_max_repeat=3" in summary
+    assert "max_repeat=7" in summary  # the aggregate stays, for continuity of the series
+
+
+def test_an_unseen_frid_has_no_summary():
+    assert FixLoopMetrics().frid_summary("m", "9") is None
+
+
+def test_the_render_summary_covers_every_frid_touched():
+    metrics = FixLoopMetrics()
+    metrics.record(UNIT_LOOP, module="m", frid="1", passed=True, output="")
+    metrics.record(CONFORMANCE_LOOP, module="m", frid="2", passed=False, output="x")
+
+    lines = metrics.render_summary()
+
+    assert len(lines) == 2
+    assert any("frid=1" in line for line in lines)
+    assert any("frid=2" in line for line in lines)
+
+
+def test_the_render_summary_is_empty_when_no_script_ran():
+    """A render that failed before any test script must not emit a misleading summary."""
+    assert FixLoopMetrics().render_summary() == []
+
+
+@pytest.mark.parametrize(
+    "first,second",
+    [
+        ("/tmp/tmpk8flk7f1.script_output", "/tmp/tmpQQQQQQQQ.script_output"),
+        (
+            "/var/folders/qk/zjb6qvds0pl4_g9vqjv3cjt80000gn/T/tmpk8flk7f1",
+            "/var/folders/p2/x9wc0mn11rs7_h1abcd2efg30000hn/T/tmpQQQQQQQQ",
+        ),
+        ("/private/var/folders/qk/zjb6qvds0pl4/T/tmpk8flk7f1", "/private/var/folders/p2/x9wc0mn11rs/T/tmpQQQQQQQQ"),
+        (r"C:\Users\runner\AppData\Local\Temp\tmpk8flk7f1", r"C:\Users\runner\AppData\Local\Temp\tmpQQQQQQQQ"),
+    ],
+    ids=["linux", "macos", "macos-private", "windows"],
+)
+def test_a_scratch_path_never_makes_one_failure_look_like_two(first, second):
+    """Two identical failures must fingerprint the same on every platform, or a repeat is
+    never recognised and the loop never looks stalled."""
+    assert failure_fingerprint(f"AssertionError at {first} line 3") == failure_fingerprint(
+        f"AssertionError at {second} line 3"
+    )
+
+
+def test_a_frid_reports_its_summary_only_once():
+    """Otherwise the end-of-render sweep counts every completed FRID a second time."""
+    metrics = FixLoopMetrics()
+    metrics.record(CONFORMANCE_LOOP, module="m", frid="1", passed=False, output="boom")
+
+    assert metrics.take_frid_summary("m", "1") is not None
+    assert metrics.take_frid_summary("m", "1") is None
+    assert metrics.render_summary() == []

--- a/tests/test_fix_loop_reporting.py
+++ b/tests/test_fix_loop_reporting.py
@@ -1,0 +1,76 @@
+"""Tests for where the fix-loop instrumentation is wired in.
+
+Counting is only useful if every script run reaches the counter and the counts survive
+the paths a render actually takes — including the failing one, where the FRID that
+exhausted its budget never reaches FinishFunctionalRequirement and would otherwise take
+its numbers with it.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from render_machine.actions.exit_with_error import ExitWithError
+from render_machine.fix_loop_metrics import (
+    CONFORMANCE_LOOP,
+    REPEATED_FAILURE_WARNING_THRESHOLD,
+    UNIT_LOOP,
+    FixLoopMetrics,
+    report_fix_loop_attempt,
+)
+
+
+def render_context():
+    context = MagicMock()
+    context.module_name = "m"
+    context.fix_loop_metrics = FixLoopMetrics()
+    context.last_error_message = "stopped"
+    context.frid_context.frid = "1"
+    return context
+
+
+def test_an_attempt_without_a_frid_is_not_counted():
+    """Test scripts also run outside a functionality (module setup); those attempts
+    belong to no FRID and must not be attributed to one."""
+    context = render_context()
+
+    report_fix_loop_attempt(context, loop=UNIT_LOOP, frid=None, passed=False, output="boom")
+
+    assert context.fix_loop_metrics.render_summary() == []
+
+
+def test_a_repeated_failure_warns_only_once_it_is_clearly_stuck():
+    context = render_context()
+
+    with patch("render_machine.fix_loop_metrics.console") as console:
+        for _ in range(REPEATED_FAILURE_WARNING_THRESHOLD - 1):
+            report_fix_loop_attempt(context, loop=CONFORMANCE_LOOP, frid="2", passed=False, output="same")
+
+        assert console.warning.call_count == 0, "warned before the loop was demonstrably stuck"
+
+        report_fix_loop_attempt(context, loop=CONFORMANCE_LOOP, frid="2", passed=False, output="same")
+
+    assert console.warning.call_count == 1
+    warning = console.warning.call_args[0][0]
+    assert "functionality 2" in warning
+    assert f"{REPEATED_FAILURE_WARNING_THRESHOLD} times in a row" in warning
+
+
+def test_progress_keeps_the_loop_quiet():
+    context = render_context()
+
+    with patch("render_machine.fix_loop_metrics.console") as console:
+        for attempt in range(6):
+            report_fix_loop_attempt(context, loop=UNIT_LOOP, frid="1", passed=False, output=f"failure {attempt}")
+
+    assert console.warning.call_count == 0
+
+
+def test_a_failed_render_still_reports_its_counts():
+    """The exhausted FRID never reaches FinishFunctionalRequirement."""
+    context = render_context()
+    report_fix_loop_attempt(context, loop=CONFORMANCE_LOOP, frid="2", passed=False, output="x")
+
+    with patch("render_machine.actions.exit_with_error.console") as console:
+        ExitWithError().execute(context, None)
+
+    reported = [call[0][0] for call in console.info.call_args_list]
+    assert any("[fix-loop]" in line and "frid=2" in line for line in reported)

--- a/tests/test_plain2code.py
+++ b/tests/test_plain2code.py
@@ -1,10 +1,12 @@
 import tempfile
 from argparse import Namespace
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import plain2code
 import plain_spec
+from plain2code_exceptions import RenderCancelledError
+from plain2code_state import RunState
 from plain_modules import PlainModule
 
 
@@ -91,3 +93,42 @@ def test_warning_covers_required_modules_for_real_plain_module(get_test_data_pat
     mock_console.warning.assert_called_once()
     warning_message = mock_console.warning.call_args.args[0]
     assert "required_with_acceptance_tests" in warning_message
+
+
+class TestRenderRecordsItsOutcome:
+    """The headless path and the TUI path both have to record how the render ended. Only
+    the TUI path did, so a headless render that failed after one module had completed
+    reported `outcome=completed` and, when the failure was an expected exception, exited 0.
+    """
+
+    @staticmethod
+    def _renderer(error=None):
+        renderer = MagicMock()
+        if error is not None:
+            renderer.render_module.side_effect = error
+        return renderer
+
+    def test_a_failure_clears_a_success_left_by_an_earlier_module(self):
+        run_state = RunState("reports.plain")
+        run_state.set_render_succeeded(True)
+        failure = RuntimeError("conformance fix loop exhausted")
+
+        returned = plain2code._render_recording_outcome(self._renderer(failure), run_state)
+
+        assert returned is failure
+        assert run_state.render_succeeded is False
+
+    def test_a_clean_run_leaves_the_outcome_alone(self):
+        run_state = RunState("reports.plain")
+        run_state.set_render_succeeded(True)
+
+        assert plain2code._render_recording_outcome(self._renderer(), run_state) is None
+        assert run_state.render_succeeded is True
+
+    def test_cancellation_is_recorded_as_cancelled_rather_than_returned(self):
+        run_state = RunState("reports.plain")
+
+        returned = plain2code._render_recording_outcome(self._renderer(RenderCancelledError()), run_state)
+
+        assert returned is None
+        assert run_state.render_cancelled is True

--- a/tests/test_render_failure_payloads.py
+++ b/tests/test_render_failure_payloads.py
@@ -9,11 +9,17 @@ showed literal braces. Both are user-facing render outcomes, so both carry a rea
 
 from unittest.mock import MagicMock
 
+from render_machine.actions.fix_conformance_test import (
+    MAX_CONFORMANCE_TEST_FIX_ATTEMPTS,
+    MAX_CONFORMANCE_TEST_RERENDER_ATTEMPTS,
+    FixConformanceTest,
+)
 from render_machine.actions.refactor_code import MAX_REFACTORING_ITERATIONS, RefactorCode
 from render_machine.actions.render_functional_requirement import (
     MAX_CODE_GENERATION_RETRIES,
     RenderFunctionalRequirement,
 )
+from render_machine.render_types import FIX_LOOP_EXHAUSTED_HINT
 
 
 def exhausted_context(**frid_attributes):
@@ -22,6 +28,15 @@ def exhausted_context(**frid_attributes):
     context.last_error_message = None
     for name, value in frid_attributes.items():
         setattr(context.frid_context, name, value)
+    return context
+
+
+def exhausted_conformance_context():
+    """A conformance loop that has spent its fix attempts and its one regeneration."""
+    context = exhausted_context()
+    ctx = context.conformance_tests_running_context
+    ctx.fix_attempts = MAX_CONFORMANCE_TEST_FIX_ATTEMPTS - 1
+    ctx.conformance_tests_render_attempts = MAX_CONFORMANCE_TEST_RERENDER_ATTEMPTS
     return context
 
 
@@ -43,7 +58,36 @@ def test_unit_test_exhaustion_names_the_functionality_and_what_to_do():
 
     assert "'1'" in message
     assert "unit tests" in message
-    assert "specification" in message
+    assert FIX_LOOP_EXHAUSTED_HINT in message
+
+
+def test_no_fix_loop_blames_the_specification_for_giving_up():
+    """Exhaustion tells us we did not converge, not that the input was wrong. Both loops used
+    to end with `Please review and rewrite the specification.`, which asserts a cause nothing
+    in the render establishes - a conformance loop has been observed patching thirteen times
+    against a failure it was not moving."""
+    unit = exhausted_context(functional_requirement_render_attempts=MAX_CODE_GENERATION_RETRIES)
+    _, unit_payload = RenderFunctionalRequirement().execute(unit, None)
+
+    conformance = exhausted_conformance_context()
+    _, conformance_payload = FixConformanceTest().execute(conformance, None)
+
+    for payload in (unit_payload, conformance_payload):
+        assert "rewrite the specification" not in payload["error"]["message"]
+
+
+def test_conformance_exhaustion_names_the_functionality_and_what_to_do():
+    context = exhausted_conformance_context()
+
+    outcome, payload = FixConformanceTest().execute(context, None)
+    message = payload["error"]["message"]
+
+    assert outcome == FixConformanceTest.LIMIT_EXCEEDED_OUTCOME
+    assert payload["error"]["type"] == "CONFORMANCE_TESTS_FIX_EXHAUSTED"
+    assert "'1'" in message
+    assert "conformance tests" in message
+    assert str(MAX_CONFORMANCE_TEST_FIX_ATTEMPTS) in message
+    assert FIX_LOOP_EXHAUSTED_HINT in message
 
 
 def test_unit_test_exhaustion_logs_the_same_reason_it_returns():

--- a/tests/test_render_failure_payloads.py
+++ b/tests/test_render_failure_payloads.py
@@ -1,0 +1,65 @@
+"""What the renderer reports when a fix loop gives up.
+
+The conformance-fix loop reports exhaustion as a typed, actionable error. The two
+client-side loops that can also give up — re-rendering a functionality because its unit
+tests never pass, and refactoring — did not: one returned no payload at all (the user saw
+`ERROR codeplain: None`), the other built its message without an f-string prefix and
+showed literal braces. Both are user-facing render outcomes, so both carry a reason.
+"""
+
+from unittest.mock import MagicMock
+
+from render_machine.actions.refactor_code import MAX_REFACTORING_ITERATIONS, RefactorCode
+from render_machine.actions.render_functional_requirement import (
+    MAX_CODE_GENERATION_RETRIES,
+    RenderFunctionalRequirement,
+)
+
+
+def exhausted_context(**frid_attributes):
+    context = MagicMock()
+    context.frid_context.frid = "1"
+    context.last_error_message = None
+    for name, value in frid_attributes.items():
+        setattr(context.frid_context, name, value)
+    return context
+
+
+def test_unit_test_exhaustion_reports_a_typed_reason():
+    context = exhausted_context(functional_requirement_render_attempts=MAX_CODE_GENERATION_RETRIES)
+
+    outcome, payload = RenderFunctionalRequirement().execute(context, None)
+
+    assert outcome == RenderFunctionalRequirement.ITERATION_LIMIT_EXCEEDED_OUTCOME
+    assert payload is not None, "a render that stopped here used to hand ExitWithError nothing to print"
+    assert payload["error"]["type"] == "UNIT_TESTS_FIX_EXHAUSTED"
+
+
+def test_unit_test_exhaustion_names_the_functionality_and_what_to_do():
+    context = exhausted_context(functional_requirement_render_attempts=MAX_CODE_GENERATION_RETRIES)
+
+    _, payload = RenderFunctionalRequirement().execute(context, None)
+    message = payload["error"]["message"]
+
+    assert "'1'" in message
+    assert "unit tests" in message
+    assert "specification" in message
+
+
+def test_unit_test_exhaustion_logs_the_same_reason_it_returns():
+    context = exhausted_context(functional_requirement_render_attempts=MAX_CODE_GENERATION_RETRIES)
+
+    _, payload = RenderFunctionalRequirement().execute(context, None)
+
+    assert context.last_error_message == payload["error"]["message"]
+
+
+def test_refactoring_exhaustion_interpolates_its_message():
+    context = exhausted_context(refactoring_iteration=MAX_REFACTORING_ITERATIONS - 1)
+
+    _, payload = RefactorCode().execute(context, None)
+    message = payload["error"]["message"]
+
+    assert "{" not in message, "the message was built without an f-string prefix"
+    assert str(MAX_REFACTORING_ITERATIONS) in message
+    assert "1" in message

--- a/tests/test_render_trailer.py
+++ b/tests/test_render_trailer.py
@@ -1,0 +1,126 @@
+"""Tests for the render trailer written to the log file.
+
+The pretty exit summary goes out through Rich's print, which bypasses logging entirely,
+so `codeplain.log` simply stopped at whatever was logged last. An artifact that ends
+mid-render is indistinguishable from a process that died silently — and when a render
+delivered a build with no entry point, that missing ending is exactly what blocked the
+diagnosis.
+
+The trailer is therefore both the fix and a probe: it is the last thing written on every
+exit path, so an artifact without one proves the log was truncated rather than merely
+uninformative.
+"""
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from cli_output.render_summary import RENDER_TRAILER_PREFIX, log_render_trailer
+
+
+def run_state(succeeded=True, cancelled=False):
+    state = MagicMock()
+    state.render_succeeded = succeeded
+    state.render_cancelled = cancelled
+    state.render_id = "5f1c25b7"
+    state.rendered_functionalities = 22
+    state.render_time_accumulated = 2934
+    state.get_live_render_time.return_value = 2934
+    state.render_generated_code_path = "/tmp/example-project/dist/"
+    return state
+
+
+@pytest.fixture
+def trailer_lines(caplog):
+    caplog.set_level(logging.INFO, logger="codeplain")
+
+    def emit(state, spec="vault_cli.plain", error_message=None):
+        caplog.clear()
+        log_render_trailer(state, spec, error_message)
+        return [record.getMessage() for record in caplog.records if RENDER_TRAILER_PREFIX in record.getMessage()]
+
+    return emit
+
+
+def test_a_completed_render_records_its_outcome(trailer_lines):
+    lines = trailer_lines(run_state())
+
+    assert len(lines) == 1
+    assert "outcome=completed" in lines[0]
+
+
+def test_the_trailer_carries_what_a_later_diagnosis_needs(trailer_lines):
+    lines = trailer_lines(run_state())
+
+    assert "render_id=5f1c25b7" in lines[0]
+    assert "functionalities=22" in lines[0]
+    assert "render_time_s=2934" in lines[0]
+    assert "render_time_live_s=2934" in lines[0]
+    assert "generated_code=/tmp/example-project/dist/" in lines[0]
+
+
+def test_a_missing_generated_code_path_is_explicit(trailer_lines):
+    """The run that delivered no entry point reported this field empty; it has to be
+    legible in the log rather than a blank gap."""
+    state = run_state()
+    state.render_generated_code_path = None
+
+    lines = trailer_lines(state)
+
+    assert "generated_code=-" in lines[0]
+
+
+def test_a_failed_render_records_the_reason(trailer_lines):
+    lines = trailer_lines(run_state(succeeded=False), error_message="Conformance tests could not be fixed.")
+
+    assert "outcome=failed" in lines[0]
+    assert "error='Conformance tests could not be fixed.'" in lines[0]
+    assert len(lines) == 1
+
+
+def test_a_cancelled_render_is_not_reported_as_failed(trailer_lines):
+    lines = trailer_lines(run_state(succeeded=False, cancelled=True))
+
+    assert "outcome=cancelled" in lines[0]
+
+
+def test_a_failure_without_a_message_still_ends_the_log(trailer_lines):
+    lines = trailer_lines(run_state(succeeded=False))
+
+    assert any("outcome=failed" in line for line in lines)
+
+
+def test_the_trailer_is_flushed_so_it_survives_an_abrupt_exit():
+    handler = MagicMock()
+    handler.level = logging.NOTSET  # logging compares record.levelno against this
+    logger = logging.getLogger("codeplain")
+    logger.addHandler(handler)
+    try:
+        log_render_trailer(run_state(), "vault_cli.plain")
+    finally:
+        logger.removeHandler(handler)
+
+    assert handler.flush.called
+
+
+def test_a_completed_render_that_still_raised_reports_the_reason(trailer_lines):
+    """A render can finish its functionalities and raise on the way out — publishing the
+    build, for instance. That combination printed a success banner, logged no reason, and
+    exited non-zero, which is how a failure on the publish path went unnoticed across a
+    whole run."""
+    lines = trailer_lines(run_state(succeeded=True), error_message="The generated build references ...")
+
+    assert any("outcome=completed" in line for line in lines)
+    assert any("error='The generated build references ...'" in line for line in lines)
+
+
+def test_a_multi_line_reason_still_leaves_the_trailer_on_one_line(trailer_lines):
+    """Written raw, a newline would end the log on an indented continuation with no prefix
+    — the shape of a truncated file."""
+    lines = trailer_lines(run_state(succeeded=False), error_message="first line\nsecond line")
+
+    assert len(lines) == 1
+    assert "\n" not in lines[0]
+    assert "outcome=failed" in lines[0]
+    assert "second line" in lines[0]

--- a/tests/test_render_trailer.py
+++ b/tests/test_render_trailer.py
@@ -104,15 +104,19 @@ def test_the_trailer_is_flushed_so_it_survives_an_abrupt_exit():
     assert handler.flush.called
 
 
-def test_a_completed_render_that_still_raised_reports_the_reason(trailer_lines):
+def test_a_render_that_raised_on_the_way_out_reports_the_reason_and_fails(trailer_lines):
     """A render can finish its functionalities and raise on the way out — publishing the
-    build, for instance. That combination printed a success banner, logged no reason, and
-    exited non-zero, which is how a failure on the publish path went unnoticed across a
-    whole run."""
+    build, for instance. That combination printed a success banner and logged no reason,
+    which is how a failure on the publish path went unnoticed across a whole run.
+
+    The reason belongs on the trailer, and so does an outcome that agrees with it: the
+    success flag is set per module, so an earlier module's success outlives the failure of
+    a later one, and a run that produced no build reported `outcome=completed`."""
     lines = trailer_lines(run_state(succeeded=True), error_message="The generated build references ...")
 
-    assert any("outcome=completed" in line for line in lines)
     assert any("error='The generated build references ...'" in line for line in lines)
+    assert any("outcome=failed" in line for line in lines)
+    assert not any("outcome=completed" in line for line in lines)
 
 
 def test_a_multi_line_reason_still_leaves_the_trailer_on_one_line(trailer_lines):
@@ -124,3 +128,18 @@ def test_a_multi_line_reason_still_leaves_the_trailer_on_one_line(trailer_lines)
     assert "\n" not in lines[0]
     assert "outcome=failed" in lines[0]
     assert "second line" in lines[0]
+
+
+class TestOutcomeAgreesWithTheReason:
+    """A trailer that says `completed` next to an `error=` is worse than no trailer: it is
+    read by tooling, and it was observed on a render that produced no code at all. The
+    success flag is set per module, so an earlier module's success outlives the failure of
+    a later one."""
+
+    def test_success_with_no_error_still_completes(self, trailer_lines):
+        assert "outcome=completed" in trailer_lines(run_state(succeeded=True))[0]
+
+    def test_a_cancelled_render_reports_cancelled_not_failed(self, trailer_lines):
+        lines = trailer_lines(run_state(succeeded=False, cancelled=True), error_message="Keyboard interrupt")
+
+        assert "outcome=cancelled" in lines[0]

--- a/tests/test_rest_error_codes.py
+++ b/tests/test_rest_error_codes.py
@@ -1,0 +1,37 @@
+"""Tests for mapping API error codes onto typed client exceptions."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+import plain2code_exceptions
+from codeplain_REST_api import CodeplainAPI
+
+
+def test_conformance_fix_exhaustion_maps_to_its_typed_exception():
+    """The server reports fix-attempt exhaustion as a structured 400; the client raises
+    the matching typed exception so the render fails with the server's message instead
+    of a raw HTTP error."""
+    api = CodeplainAPI(api_key="test-key", console=MagicMock())
+
+    with pytest.raises(plain2code_exceptions.ConformanceTestsFixExhausted, match="after 10 attempts"):
+        api._raise_for_error_code(
+            {
+                "error_code": "ConformanceTestsFixExhausted",
+                "message": "Could not fix conformance tests issue for functional requirement 1 after 10 attempts.",
+            }
+        )
+
+
+def test_an_unknown_error_code_still_falls_through_silently():
+    api = CodeplainAPI(api_key="test-key", console=MagicMock())
+
+    api._raise_for_error_code({"error_code": "SomeFutureCode", "message": "whatever"})  # does not raise
+
+
+def test_the_exhaustion_error_is_expected_rather_than_a_crash():
+    """A render outcome the user acts on. Left out of this tuple it reaches the top level as
+    an unexpected exception and is reported to Sentry as a crash."""
+    from plain2code import EXPECTED_EXCEPTIONS
+
+    assert plain2code_exceptions.ConformanceTestsFixExhausted in EXPECTED_EXCEPTIONS

--- a/tests/test_rest_error_codes.py
+++ b/tests/test_rest_error_codes.py
@@ -73,7 +73,7 @@ class TestErrorCodesAreReadOnEveryDeclinedStatus:
         api, response = self._api_returning(500, {"error_code": "InternalServerError", "message": "boom"})
 
         with patch("requests.post", return_value=response):
-            with pytest.raises(plain2code_exceptions.InternalServerError, match="support@codeplain.ai"):
+            with pytest.raises(plain2code_exceptions.InternalServerError, match="render log"):
                 api.post_request("https://api.example/x", {}, {}, None, num_retries=0)
 
     def test_a_success_is_returned_untouched(self):

--- a/tests/test_rest_error_codes.py
+++ b/tests/test_rest_error_codes.py
@@ -1,15 +1,16 @@
 """Tests for mapping API error codes onto typed client exceptions."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
 
 import plain2code_exceptions
 from codeplain_REST_api import CodeplainAPI
 
 
 def test_conformance_fix_exhaustion_maps_to_its_typed_exception():
-    """The server reports fix-attempt exhaustion as a structured 400; the client raises
+    """The server reports fix-attempt exhaustion as a structured error; the client raises
     the matching typed exception so the render fails with the server's message instead
     of a raw HTTP error."""
     api = CodeplainAPI(api_key="test-key", console=MagicMock())
@@ -35,3 +36,49 @@ def test_the_exhaustion_error_is_expected_rather_than_a_crash():
     from plain2code import EXPECTED_EXCEPTIONS
 
     assert plain2code_exceptions.ConformanceTestsFixExhausted in EXPECTED_EXCEPTIONS
+
+
+class TestErrorCodesAreReadOnEveryDeclinedStatus:
+    """The client used to consult `error_code` only on 400, so every structured error the
+    server returns with a 500 - its own `InternalServerError` among them - reached the user
+    as `500 Server Error: INTERNAL SERVER ERROR for url: <internal endpoint>`. The message
+    the code was paired with never printed."""
+
+    @staticmethod
+    def _api_returning(status, body):
+        response = MagicMock()
+        response.status_code = status
+        response.ok = 200 <= status < 300
+        response.json.return_value = body
+        response.raise_for_status.side_effect = requests.exceptions.HTTPError(f"{status} Server Error")
+
+        api = CodeplainAPI(api_key="test-key", console=MagicMock())
+        api.api_url = "https://api.example"
+        return api, response
+
+    def test_a_500_carrying_an_error_code_raises_the_typed_exception(self):
+        api, response = self._api_returning(
+            500,
+            {
+                "error_code": "ConformanceTestsFixExhausted",
+                "message": "The conformance tests for functionality 1 still failed.",
+            },
+        )
+
+        with patch("requests.post", return_value=response):
+            with pytest.raises(plain2code_exceptions.ConformanceTestsFixExhausted, match="still failed"):
+                api.post_request("https://api.example/x", {}, {}, None, num_retries=0)
+
+    def test_the_generic_server_error_reaches_the_user_as_its_own_message(self):
+        api, response = self._api_returning(500, {"error_code": "InternalServerError", "message": "boom"})
+
+        with patch("requests.post", return_value=response):
+            with pytest.raises(plain2code_exceptions.InternalServerError, match="support@codeplain.ai"):
+                api.post_request("https://api.example/x", {}, {}, None, num_retries=0)
+
+    def test_a_success_is_returned_untouched(self):
+        api, response = self._api_returning(200, {"result": "ok"})
+        response.raise_for_status.side_effect = None
+
+        with patch("requests.post", return_value=response):
+            assert api.post_request("https://api.example/x", {}, {}, None, num_retries=0) == {"result": "ok"}


### PR DESCRIPTION
**Client half of group B.** The server half is `Codeplain-ai/codeplain-api#140`, and **this must land first** — see *Ordering* below.

Mostly observability: nothing acts on what is measured. Two exceptions, both user-facing and both called out.

## What is in it

* **Map the** `ConformanceTestsFixExhausted` **error code**, and add it to `EXPECTED_EXCEPTIONS` so an exhausted fix loop reports as a render outcome rather than a crash. Inert until the server emits the code.
* **Report render failures as typed reasons** instead of printing the raw payload an action returned. Users were seeing a raw dict, or the literal word `None`.
* **Count attempts per loop per functionality, and fingerprint each failure**, with volatile parts of the output normalized out — including temporary paths on all three platforms, so two identical failures fingerprint the same on macOS and Windows as well as Linux. Reported per loop, because one aggregate reads as whichever loop the reader has in mind.
* **Write one summary line at the end of every render** — identifier, outcome, functionality count, elapsed time both banked and live, whether code was produced — on the success and failure paths alike, always as a single physical line so the last line of a log is always the trailer.

### Two behaviour changes

* **A failed render now reports as failed.** The success flag is set per module, so a render that failed after an earlier module completed was still holding that module's success: the trailer said `outcome=completed` next to its own error and an empty generated-code path. It also decides the exit code, which is `0` when the failure is one of `EXPECTED_EXCEPTIONS` — so once the server returns a typed error for an exhausted fix loop, that render would have started exiting `0`. Found in a benchmark log, fixed here.
* **The client reads the server's `error_code` on every status it declines on, not only `400`.** This is what makes a named 500 legible. It also means the server's existing `InternalServerError` envelope reaches a user for the first time — it has only ever been sent with a 500, so its "report this to us" message has never printed; every generic server error surfaced as `500 Server Error: INTERNAL SERVER ERROR for url: <internal endpoint>`, leaking the path.

### Error wording

Two client-side fix loops ended with *"Please review and rewrite the specification."* — one added by this branch, one on `main` since 2026-04-23. Both are gone. Exhaustion tells us we did not converge, not that the input was wrong: a conformance loop has been observed patching thirteen times against a failure it was not moving. Each reason now names the loop, the functionality and the attempt count, and points at the log. The shared closing sentence lives in one constant so the sites cannot drift. The same sentence was removed from the server in api#140.

The support address was also dropped from the internal-server-error message, which for the reason above had never actually printed.

## Ordering

**Land this before api#140.** Not a coordinated deploy — shipping the server first is inert rather than harmful — but the server's named 500 is unreadable until this ships. This PR is independently useful on its own, because of the `InternalServerError` fix above.

Independent of group A entirely. Shares the `finally` block in `plain2code.py` with `Codeplain-ai/codeplain#293`; whichever lands second resolves a few lines.

## Verification

All gates green, 442 passed. Every behaviour change carries a regression test verified to fail without the fix — including one that asserts *neither* fix loop blames the specification, so it cannot be quietly reintroduced.

Exercised on ten benchmark examples: the `[fix-loop]` and `[render-trailer]` lines read well and answered real questions about the run. All three reworded messages were then observed live in production logs.

Part of Codeplain-ai/codeplain#273 / [ENG-217](https://linear.app/codeplain/issue/ENG-217).
