### PR TITLE
Notify Slack when a dev build is published ENG-234

### DIFF
--- a/.github/workflows/publish-dev-to-pypi.yml
+++ b/.github/workflows/publish-dev-to-pypi.yml
@@ -30,6 +30,7 @@ jobs:
       contents: read
     outputs:
       should-publish: ${{ steps.version.outputs.should-publish }}
+      version: ${{ steps.version.outputs.version }}
 
     steps:
       - uses: actions/checkout@v4
@@ -79,6 +80,7 @@ jobs:
           echo "Derived version: $RAW -> $VERSION"
           echo "SETUPTOOLS_SCM_PRETEND_VERSION=$VERSION" >> $GITHUB_ENV
           echo "should-publish=true" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Build package
         if: steps.version.outputs.should-publish == 'true'
@@ -125,8 +127,18 @@ jobs:
           # version should be a no-op, not a red build.
           skip-existing: true
 
-      # Success is deliberately quiet: this runs on every merge to main, which
-      # is already announced elsewhere. Only failures ping.
+      - name: Notify Slack (success)
+        if: ${{ success() && env.SLACK_WEBHOOK_URL != '' }}
+        env:
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          # Spell out the --pre install: a plain "pip install codeplain" will
+          # NOT pick this up, which otherwise reads as a broken publish.
+          TEXT="*Codeplain Client*: dev build \`$VERSION\` published to PyPI :test_tube:. Normal installs are unaffected — try it with \`pip install --pre codeplain==$VERSION\`. Pre-release builds talk to \`api.test.codeplain.ai\` by default."
+          curl -s -X POST "$SLACK_WEBHOOK_URL" \
+            -H 'Content-type: application/json' \
+            --data "$(jq -n --arg t "$TEXT" '{text:$t}')"
+
       - name: Notify Slack (failure)
         if: ${{ failure() && env.SLACK_WEBHOOK_URL != '' }}
         run: |


### PR DESCRIPTION
Follow-up to #302.

## Problem

The dev publish workflow only notified Slack on failure, so `0.3.10.dev1` went to PyPI with no announcement. The run succeeded — the silence was a deliberate choice in #302 (reasoning: a ping on every merge duplicates `nofity-slack-on-main-merge.yml`), but it makes a successful publish indistinguishable from one that never ran.

## Change

Announce successful dev publishes, carrying the version and the install command:

> *Codeplain Client*: dev build `0.3.10.dev2` published to PyPI 🧪. Normal installs are unaffected — try it with `pip install --pre codeplain==0.3.10.dev2`. Pre-release builds talk to `api.test.codeplain.ai` by default.

Spelling out `--pre` matters: a plain `pip install codeplain` silently returns the older stable release, which reads as a broken publish. The message also names the API the build defaults to, since that differs from stable.

The version is now exposed as a `build` job output so the publish job can name it.

## Testing

Verified the message renders valid JSON via `jq` (backticks and em dash intact); workflow YAML parses and the job wiring is unchanged apart from the new step and output.