### PR TITLE
[ENG-206] Reject binary linked resources during --dry-run

### DIFF
--- a/plain2code.py
+++ b/plain2code.py
@@ -203,6 +203,15 @@ def warn_if_acceptance_tests_without_conformance_script(plain_module, args) -> N
     )
 
 
+def validate_linked_resources(plain_module) -> None:
+    """Load every linked resource exactly the way rendering does, so dry-run
+    surfaces the same errors (binary file, missing file, oversized base64 blob)."""
+    for module in plain_module.all_required_modules + [plain_module]:
+        resources_list: list[dict] = []
+        plain_spec.collect_linked_resources(module.plain_source, resources_list, None, True)
+        file_utils.load_linked_resources(module.template_dirs, resources_list, module.module_name)
+
+
 def render(  # noqa: C901
     plain_module: plain_modules.PlainModule,
     args,
@@ -393,6 +402,12 @@ def main():  # noqa: C901
         return
 
     if args.dry_run:
+        try:
+            validate_linked_resources(plain_module)
+        except Exception as e:
+            console.error(f"Error: {str(e)}")
+            return
+
         console.info("Printing dry run output...\n")
         render_range = plain_spec.compute_render_range(args, plain_module.plain_source)
         print_dry_run_output(plain_module.plain_source, render_range)

--- a/tests/test_dry_run_link_validation.py
+++ b/tests/test_dry_run_link_validation.py
@@ -1,0 +1,60 @@
+"""Regression tests for linked-resource validation during --dry-run.
+
+A linked resource must be a single text-based file. Rendering rejects binary
+targets in ``file_utils.load_linked_resources`` (a failed UTF-8 decode raises
+``UnsupportedResourceType``); dry-run must surface the same errors through
+``plain2code.validate_linked_resources``, which reuses that exact mechanism.
+"""
+
+import pytest
+
+from plain2code import validate_linked_resources
+from plain2code_exceptions import UnsupportedResourceType
+from plain_modules import PlainModule
+
+PLAIN_TEMPLATE = """***definitions***
+
+- :Widget: is an item managed by the application.
+  - Its icon is [the widget resource](resources/{resource_name}).
+
+***implementation reqs***
+
+- Implementation should be in Python.
+
+***functional specs***
+
+- A :Widget: can be created.
+"""
+
+
+def _make_module(tmp_path, monkeypatch, resource_name, resource_bytes):
+    resources_dir = tmp_path / "resources"
+    resources_dir.mkdir()
+    (resources_dir / resource_name).write_bytes(resource_bytes)
+    (tmp_path / "binlink.plain").write_text(PLAIN_TEMPLATE.format(resource_name=resource_name))
+
+    # Link targets are resolved relative to the current working directory at parse time.
+    monkeypatch.chdir(tmp_path)
+    return PlainModule("binlink.plain", str(tmp_path / "build"), [str(tmp_path)])
+
+
+def test_dry_run_validation_rejects_binary_linked_resource(tmp_path, monkeypatch):
+    module = _make_module(tmp_path, monkeypatch, "image.png", b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\xff\xfe\xfd")
+
+    with pytest.raises(UnsupportedResourceType) as exc_info:
+        validate_linked_resources(module)
+
+    assert "resources/image.png" in str(exc_info.value)
+    assert "binary file" in str(exc_info.value)
+
+
+def test_dry_run_validation_accepts_text_file_with_unusual_extension(tmp_path, monkeypatch):
+    module = _make_module(tmp_path, monkeypatch, "notes.xyz123", b"plain text content\n")
+
+    validate_linked_resources(module)
+
+
+def test_dry_run_validation_accepts_empty_file(tmp_path, monkeypatch):
+    module = _make_module(tmp_path, monkeypatch, "empty.txt", b"")
+
+    validate_linked_resources(module)


### PR DESCRIPTION
Dry-run only ran the parse-time link checks (missing target, directory, absolute path, .plain), so a linked PNG/PDF/ZIP passed validation and the error only surfaced at render time. Dry-run now loads every linked resource through the same collect_linked_resources + load_linked_resources path that RenderContext uses for rendering, so a binary target fails fast with the identical UnsupportedResourceType message (and missing-file / oversized base64 errors surface at dry-run too).

Regression tests cover binary rejection, unusual-extension text acceptance, and the empty-file case.