### PR TITLE
Fix/dont substitute emoji in log text

### DIFF
--- a/plain2code_console.py
+++ b/plain2code_console.py
@@ -27,7 +27,9 @@ class Plain2CodeConsole(Console):
     DEBUG_STYLE = Style(color="purple")
 
     def __init__(self):
-        super().__init__()
+        # Emoji shortcodes must never be substituted. Set on the console because the
+        # emoji flag of Console.print does not reach text inside renderables like Tree.
+        super().__init__(emoji=False)
         try:
             import tiktoken
 
@@ -66,13 +68,12 @@ class Plain2CodeConsole(Console):
         """
         logger.log(level, " ".join(map(str, args)), extra={"log_color": color})
         style = base_style + Style(color=color) if color else base_style
-        # Log messages must render exactly as logged: don't interpret square brackets
-        # in interpolated content (error texts, file names) as Rich markup, and don't
-        # let the repr highlighter restyle brackets and numbers inside them.
-        # Don't let Rich substitute emoji shortcodes with glyphs. Literal emojis unaffected.
+        # Messages must render exactly as logged and not pick its own styling:
+        # -- no Rich markup (via square brackets) in interpolated content (error texts, file names)
+        # -- no repr highlighter restyling brackets and numbers inside them.
+        # -- emoji are off console-wide via __init__
         kwargs.setdefault("markup", False)
         kwargs.setdefault("highlight", False)
-        kwargs.setdefault("emoji", False)
         super().print(*args, **kwargs, style=style)
 
     def print_list(self, items, style=None):

--- a/plain2code_console.py
+++ b/plain2code_console.py
@@ -27,8 +27,6 @@ class Plain2CodeConsole(Console):
     DEBUG_STYLE = Style(color="purple")
 
     def __init__(self):
-        # Emoji shortcodes must never be substituted. Set on the console because the
-        # emoji flag of Console.print does not reach text inside renderables like Tree.
         super().__init__(emoji=False)
         try:
             import tiktoken
@@ -71,7 +69,7 @@ class Plain2CodeConsole(Console):
         # Messages must render exactly as logged and not pick its own styling:
         # -- no Rich markup (via square brackets) in interpolated content (error texts, file names)
         # -- no repr highlighter restyling brackets and numbers inside them.
-        # -- emoji are off console-wide via __init__
+        # -- no emoji substitution, but it's set False in __init__, otherwise it won't reach renderables like Trees
         kwargs.setdefault("markup", False)
         kwargs.setdefault("highlight", False)
         super().print(*args, **kwargs, style=style)

--- a/plain2code_console.py
+++ b/plain2code_console.py
@@ -69,8 +69,10 @@ class Plain2CodeConsole(Console):
         # Log messages must render exactly as logged: don't interpret square brackets
         # in interpolated content (error texts, file names) as Rich markup, and don't
         # let the repr highlighter restyle brackets and numbers inside them.
+        # Don't let Rich substitute emoji shortcodes with glyphs. Literal emojis unaffected.
         kwargs.setdefault("markup", False)
         kwargs.setdefault("highlight", False)
+        kwargs.setdefault("emoji", False)
         super().print(*args, **kwargs, style=style)
 
     def print_list(self, items, style=None):

--- a/tests/test_console_log_styles.py
+++ b/tests/test_console_log_styles.py
@@ -79,6 +79,17 @@ class TestConsoleColorParam:
         assert "[/closing]" in capture.get()
 
 
+class TestTerminalTextRendersVerbatim:
+    """Message text must reach the terminal unchanged, and must not pick its own styling."""
+
+    def test_concept_name_matching_emoji_prints_verbatim(self):
+        console = Plain2CodeConsole()
+        with console.capture() as capture:
+            console.info("Syntax error: Invalid concept: :Package:")
+        assert ":Package:" in capture.get()
+        assert "📦" not in capture.get()
+
+
 class TestLoggingHandlerForwardsColor:
     """LoggingHandler must forward the log_color record attribute into LogMessageEmitted."""
 

--- a/tests/test_console_log_styles.py
+++ b/tests/test_console_log_styles.py
@@ -72,20 +72,46 @@ class TestConsoleColorParam:
 
 
 class TestTerminalTextRendersVerbatim:
-    """Message text must reach the terminal unchanged, and must not pick its own styling."""
+    """
+    Message text must reach the terminal unchanged, and must not influence its own
+    styling. Colors are still applied but they are chosen by the call, never parsed
+    out of the text:
+     - Rich markup tags must not be interpreted
+     - the repr highlighter must not restyle brackets and numbers
+     - emoji shortcodes must not be substituted by glyphs
+    """
 
-    def test_bracketed_error_text_prints_verbatim(self):
-        console, handler = make_console_with_capture()
-        console.quiet = False
+    def test_markup_closing_tag_prints_verbatim(self):
+        console = Plain2CodeConsole()
         with console.capture() as capture:
-            console.info("Error: [Errno 8] failed [/closing] tag", color=RETRY_COLOR)
-        assert "[Errno 8]" in capture.get()
+            console.error("Error: [/closing] tag")
+        # markup=True raises MarkupError on an unmatched closing tag
         assert "[/closing]" in capture.get()
+
+    def test_markup_style_tag_prints_verbatim(self):
+        console = Plain2CodeConsole()
+        with console.capture() as capture:
+            console.error("Error: [bold]important text")
+        # markup=True silently consumes the tag and styles the rest
+        assert "[bold]" in capture.get()
+
+    def test_bracketed_number_prints_verbatim(self, monkeypatch):
+        # Rich emits no ANSI unless it believes it is writing to a colored terminal
+        # (FORCE_COLOR alone is not enough: TERM=dumb still resolves to no colors)
+        monkeypatch.setenv("FORCE_COLOR", "1")
+        monkeypatch.setenv("TERM", "xterm-256color")
+        console = Plain2CodeConsole()
+        assert console.color_system is not None  # should fail test immediately if no colors
+
+        with console.capture() as capture:
+            console.error("Error: [Errno 8] failed")
+        # highlight=True breaks this up with colour codes
+        assert "[Errno 8]" in capture.get()
 
     def test_concept_name_matching_emoji_prints_verbatim(self):
         console = Plain2CodeConsole()
         with console.capture() as capture:
-            console.info("Syntax error: Invalid concept: :Package:")
+            console.error("Syntax error: Invalid concept: :Package:")
         assert ":Package:" in capture.get()
         assert "📦" not in capture.get()
 

--- a/tests/test_console_log_styles.py
+++ b/tests/test_console_log_styles.py
@@ -70,6 +70,10 @@ class TestConsoleColorParam:
 
         assert handler.records[0].log_color is None
 
+
+class TestTerminalTextRendersVerbatim:
+    """Message text must reach the terminal unchanged, and must not pick its own styling."""
+
     def test_bracketed_error_text_prints_verbatim(self):
         console, handler = make_console_with_capture()
         console.quiet = False
@@ -77,10 +81,6 @@ class TestConsoleColorParam:
             console.info("Error: [Errno 8] failed [/closing] tag", color=RETRY_COLOR)
         assert "[Errno 8]" in capture.get()
         assert "[/closing]" in capture.get()
-
-
-class TestTerminalTextRendersVerbatim:
-    """Message text must reach the terminal unchanged, and must not pick its own styling."""
 
     def test_concept_name_matching_emoji_prints_verbatim(self):
         console = Plain2CodeConsole()

--- a/tests/test_console_log_styles.py
+++ b/tests/test_console_log_styles.py
@@ -116,6 +116,25 @@ class TestTerminalTextRendersVerbatim:
         assert "📦" not in capture.get()
 
 
+class TestPrintHelpersDoNotSubstituteEmoji:
+    """
+    Same rule as TestTerminalTextRendersVerbatim, for the two helpers that bypass _log_and_print.
+    Only emoji is covered here, markup and highlighting still apply to them.
+    """
+
+    def test_print_list_does_not_substitute_emoji(self):
+        console = Plain2CodeConsole()
+        with console.capture() as capture:
+            console.print_list(["The :Package: is a concept"])
+        assert ":Package:" in capture.get()
+
+    def test_print_files_does_not_substitute_emoji_in_tree_labels(self):
+        console = Plain2CodeConsole()
+        with console.capture() as capture:
+            console.print_files("Files added:", "build", {":Package:.py": "x"})
+        assert ":Package:" in capture.get()
+
+
 class TestLoggingHandlerForwardsColor:
     """LoggingHandler must forward the log_color record attribute into LogMessageEmitted."""
 


### PR DESCRIPTION
Rich substitutes emoji shortcodes by default, so a `.plain` concept whose name matches one was replaced by a glyph.

```
Syntax error: Concept 👻 is not defined in the definitions.
Syntax error: Concept :Ghost: is not defined in the definitions.
```

This is not exotic: `Package`, `Book`, `Key`, `Bug`, `Lock`, `Link`, `Ghost` are all shortcodes and pretty reasonable concepts one might use in a spec.

**Change:** 
 - one line, the console is built with `emoji=False`. 
 - Set on the console, not per call, because `Console.print(emoji=False)` doesn't reach renderables
   -  a file named `:Package:.py` in the `print_files` tree still came out as `📦.py`.

**Tests:** 
 - `_log_and_print` already disabled `markup` and `highlight`, but one test asserted all three at once, so a markup failure hid the rest, and its highlighting assertion could never fail (Rich emits no colour off a terminal).
 -  Now one test per setting, colour forced where needed. 
 - Class renamed to `TestTerminalTextRendersVerbatim` which asserts on terminal output, not log records.

**Out of scope:** 
 - `print_list` and the `print_files` header still render caller data as markup, and tree labels still parse it (`[red]deleted[/red]` needs it).  - Emoji is fixed for all of them here but brackets aren't. 
  - Tracked separately and `escape()` is not the fix there: it doubles a trailing backslash, so `build\` renders as `build\\`.

**Verification:** 
 - `450 passed` passed, lint clean, manually checked via `--dry-run` with concepts named `:Ghost:` and `:Réunion:` (the latter hits the other error string for invalid concept, in `concept_utils.py`).