### PR TITLE
Tell the API which terminal state a render reached

### DIFF
--- a/codeplain_REST_api.py
+++ b/codeplain_REST_api.py
@@ -11,6 +11,10 @@ from plain2code_state import RunState
 MAX_RETRIES = 4
 RETRY_DELAY = 3
 
+# A report the render does not consume must not be able to hold the process open
+# at exit, and requests waits indefinitely by default.
+REPORT_TIMEOUT_SECONDS = 5
+
 RETRY_ERROR_CODES = [
     "LLMInternalError",
 ]
@@ -125,6 +129,7 @@ class CodeplainAPI:
         run_state: Optional[RunState],
         num_retries: int = MAX_RETRIES,
         silent: bool = False,
+        timeout: Optional[int] = None,
     ):
         if run_state is not None:
             self._extend_payload_with_run_state(payload, run_state)
@@ -134,7 +139,7 @@ class CodeplainAPI:
 
         for attempt in range(num_retries + 1):
             try:
-                response = requests.post(endpoint_url, headers=headers, json=payload)
+                response = requests.post(endpoint_url, headers=headers, json=payload, timeout=timeout)
 
                 try:
                     response_json = response.json()
@@ -172,6 +177,27 @@ class CodeplainAPI:
             "api_key": self.api_key,
         }
         return self.post_request(endpoint_url, headers, payload, None, num_retries=0, silent=True)
+
+    def render_finished(self, outcome: str, run_state: RunState):
+        """Report the terminal state a render reached.
+
+        Called once per render, whatever the outcome. The render state machine
+        lives here, so the API cannot tell a finished render from one still
+        going; it has to be told.
+
+        No retries and no console output: a report has no result the render
+        needs, and must not add minutes to a render that has already ended nor
+        print retry noise over the exit summary.
+        """
+        endpoint_url = f"{self.api_url}/render_finished"
+        headers = {"X-API-Key": self.api_key, "Content-Type": "application/json"}
+        payload = {
+            "outcome": outcome,
+        }
+
+        return self.post_request(
+            endpoint_url, headers, payload, run_state, num_retries=0, silent=True, timeout=REPORT_TIMEOUT_SECONDS
+        )
 
     def render_functional_requirement(
         self,

--- a/plain2code.py
+++ b/plain2code.py
@@ -61,6 +61,11 @@ from tui.plain_module_render_choice_tui import PlainModuleRenderChoiceTUI
 DEFAULT_TEMPLATE_DIRS = "standard_template_library"
 RENDER_THREAD_SHUTDOWN_TIMEOUT = 0.7
 
+# The terminal states a render can reach, as the API names them.
+RENDER_OUTCOME_COMPLETED = "completed"
+RENDER_OUTCOME_FAILED = "failed"
+RENDER_OUTCOME_CANCELLED = "cancelled"
+
 # Exceptions that represent expected, user-facing error conditions. They are
 # reported to the user directly and must never be sent to Sentry as crashes.
 EXPECTED_EXCEPTIONS = (
@@ -177,6 +182,46 @@ def _check_connection(codeplainAPI: codeplain_api.CodeplainAPI) -> Optional[str]
     return response.get("user_email")
 
 
+def _render_outcome(run_state: RunState) -> str:
+    """Name the terminal state a render reached.
+
+    Cancellation is tested first. A cancelled render leaves render_succeeded
+    False, so asking about success first would report it as a failure.
+    """
+    if run_state.render_cancelled:
+        return RENDER_OUTCOME_CANCELLED
+    if run_state.render_succeeded:
+        return RENDER_OUTCOME_COMPLETED
+    return RENDER_OUTCOME_FAILED
+
+
+def report_render_finished(codeplainAPI: codeplain_api.CodeplainAPI, run_state: RunState) -> None:
+    """Tell the API which terminal state this render reached.
+
+    The API cannot work it out for itself - the state machine lives here - and
+    main()'s finally is the one place that sees every ending: success, failure,
+    cancellation, an unexpected crash and a keyboard interrupt alike. The state
+    machine's own completed and failed hooks see only two of the five.
+
+    Reported only once the connection check has set a user email, which is
+    exactly the condition "the API knows who we are". A missing key, an invalid
+    key and an outdated client all leave it unset, and none of them got as far
+    as a render.
+
+    Never raises. A report must not change the exit code, and must not mask the
+    error that ended the render.
+    """
+    if not run_state.user_email:
+        return
+
+    try:
+        codeplainAPI.render_finished(_render_outcome(run_state), run_state)
+    except Exception:
+        # Deliberately silent: logging has stopped by now, and a failed report
+        # is not the user's problem.
+        pass
+
+
 def warn_if_acceptance_tests_without_conformance_script(plain_module, args) -> None:
     """Warn when any loaded module (including required modules) defines acceptance tests
     but no conformance tests script is configured.
@@ -214,6 +259,7 @@ def validate_linked_resources(plain_module) -> None:
 
 def render(  # noqa: C901
     plain_module: plain_modules.PlainModule,
+    codeplainAPI: codeplain_api.CodeplainAPI,
     args,
     run_state: RunState,
     event_bus: EventBus,
@@ -223,10 +269,6 @@ def render(  # noqa: C901
     render_range = None
     if args.render_range or args.render_from:
         render_range = plain_spec.compute_render_range(args, plain_module.plain_source)
-
-    codeplainAPI = codeplain_api.CodeplainAPI(args.api_key, console)
-    assert args.api is not None and args.api != "", "API URL is required"
-    codeplainAPI.api_url = args.api
 
     run_state.user_email = _check_connection(codeplainAPI)
 
@@ -419,6 +461,10 @@ def main():  # noqa: C901
     if not args.api:
         args.api = system_config.default_api_url
 
+    assert args.api is not None and args.api != "", "API URL is required"
+    codeplainAPI = codeplain_api.CodeplainAPI(args.api_key, console)
+    codeplainAPI.api_url = args.api
+
     run_state = RunState(spec_filename=args.filename, replay_with=args.replay_with)
 
     if args.headless:
@@ -438,7 +484,7 @@ def main():  # noqa: C901
             raise MissingAPIKey(
                 "Your API key is required. Please set the CODEPLAIN_API_KEY environment variable or provide it with the --api-key argument.\n"
             )
-        render(plain_module, args, run_state, event_bus, default_log_level)
+        render(plain_module, codeplainAPI, args, run_state, event_bus, default_log_level)
     except BaseException as e:
         if isinstance(e, KeyboardInterrupt):
             error_message = "Keyboard interrupt"
@@ -460,6 +506,8 @@ def main():  # noqa: C901
         # Remove any scratch extractions created for archive-only ("<module>.module") modules.
         for module in plain_module.all_required_modules + [plain_module]:
             module.cleanup_scratch()
+        # Last, so nothing the user is waiting for sits behind a network call.
+        report_render_finished(codeplainAPI, run_state)
 
     if args.headless and (exc_info is not None or not run_state.render_succeeded):
         sys.exit(1)

--- a/tests/test_render_finished_report.py
+++ b/tests/test_render_finished_report.py
@@ -1,0 +1,182 @@
+"""Tests for reporting a render's terminal state to the API.
+
+The render state machine lives in the client, so the API only learns how a
+render ended because main() tells it. Two things are worth proving: that the
+outcome names the right ending, and that main() reports on every path out -
+including the ones the state machine never sees, like a keyboard interrupt.
+"""
+
+from argparse import Namespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import plain2code
+from plain2code_exceptions import InvalidAPIKey
+from plain2code_state import RunState
+
+
+def make_run_state(succeeded=False, cancelled=False, user_email="user@codeplain.ai"):
+    run_state = RunState(spec_filename="project.plain")
+    run_state.set_render_succeeded(succeeded)
+    if cancelled:
+        run_state.set_render_cancelled()
+    run_state.user_email = user_email
+    return run_state
+
+
+class TestRenderOutcome:
+    def test_a_successful_render_is_completed(self):
+        assert plain2code._render_outcome(make_run_state(succeeded=True)) == "completed"
+
+    def test_an_unsuccessful_render_is_failed(self):
+        assert plain2code._render_outcome(make_run_state(succeeded=False)) == "failed"
+
+    def test_a_cancelled_render_is_cancelled(self):
+        """A cancelled render leaves render_succeeded False, so cancellation has to
+        be asked about first or it would be reported as a failure."""
+        assert plain2code._render_outcome(make_run_state(cancelled=True)) == "cancelled"
+
+    def test_cancellation_wins_over_a_success_already_recorded(self):
+        """Cancelling during the dist step leaves both flags set."""
+        assert plain2code._render_outcome(make_run_state(succeeded=True, cancelled=True)) == "cancelled"
+
+
+class TestReportRenderFinished:
+    def test_reports_the_outcome_with_the_render_state(self):
+        api = MagicMock()
+        run_state = make_run_state(succeeded=True)
+
+        plain2code.report_render_finished(api, run_state)
+
+        api.render_finished.assert_called_once_with("completed", run_state)
+
+    def test_says_nothing_when_the_api_never_identified_us(self):
+        """user_email is set by the connection check, so an absent one means a
+        missing key, an invalid key or an outdated client - none of which rendered."""
+        api = MagicMock()
+
+        plain2code.report_render_finished(api, make_run_state(user_email=None))
+
+        api.render_finished.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "failure",
+        [
+            ConnectionError("api unreachable"),
+            TimeoutError("api slow"),
+            RuntimeError("something else entirely"),
+        ],
+    )
+    def test_a_failed_report_never_propagates(self, failure):
+        """The report is the last thing a render does. It must not become the
+        reason the render looks like it failed."""
+        api = MagicMock()
+        api.render_finished.side_effect = failure
+
+        plain2code.report_render_finished(api, make_run_state(succeeded=True))
+
+
+def make_args(api_key="test-key", headless=False):
+    return Namespace(
+        version=False,
+        status=False,
+        full_plain=False,
+        dry_run=False,
+        api_key=api_key,
+        api="https://api.example.com",
+        filename="project.plain",
+        template_dir=None,
+        build_folder="build",
+        render_range=None,
+        render_from=None,
+        headless=headless,
+        replay_with=None,
+        log_to_file=False,
+        log_file_name="codeplain.log",
+        conformance_tests_script=None,
+        unittests_script=None,
+        prepare_environment_script=None,
+    )
+
+
+def run_main(render_side_effect=None, api_key="test-key"):
+    """Drive main() with everything but the reporting path stubbed out.
+
+    render() is replaced, so the stub is what decides how the render "ended" -
+    which is the point: the report must be made from main()'s finally whatever
+    render did, not from inside the state machine.
+
+    Returns the API client mock so the caller can inspect the report.
+    """
+    api = MagicMock()
+
+    def fake_render(plain_module, codeplainAPI, args, run_state, event_bus, default_log_level="INFO"):
+        run_state.user_email = "user@codeplain.ai"
+        if render_side_effect is not None:
+            render_side_effect(run_state)
+
+    with (
+        patch("plain2code.parse_arguments", return_value=make_args(api_key=api_key)),
+        patch("plain2code.file_utils.get_template_directories", return_value=["templates"]),
+        patch("plain2code.plain_modules.PlainModule", return_value=MagicMock(all_required_modules=[])),
+        patch("plain2code.setup_logging", return_value="INFO"),
+        patch("plain2code.initialize_telemetry"),
+        patch("plain2code.stop_narrating"),
+        patch("plain2code.print_exit_summary"),
+        patch("plain2code.dump_crash_logs"),
+        patch("plain2code.capture_crash"),
+        patch("plain2code.codeplain_api.CodeplainAPI", return_value=api),
+        patch("plain2code.render", side_effect=fake_render),
+    ):
+        plain2code.main()
+
+    return api
+
+
+class TestMainReportsEveryEnding:
+    """main()'s finally is the only place that sees all of these."""
+
+    def test_a_completed_render_is_reported(self):
+        api = run_main(lambda run_state: run_state.set_render_succeeded(True))
+
+        assert api.render_finished.call_args.args[0] == "completed"
+
+    def test_a_failed_render_is_reported(self):
+        def fail(run_state):
+            run_state.set_render_succeeded(False)
+            raise Exception("rendering blew up")
+
+        api = run_main(fail)
+
+        assert api.render_finished.call_args.args[0] == "failed"
+
+    def test_an_expected_error_is_reported_as_a_failure(self):
+        def fail(run_state):
+            raise InvalidAPIKey("key went stale mid-render")
+
+        api = run_main(fail)
+
+        assert api.render_finished.call_args.args[0] == "failed"
+
+    def test_a_cancelled_render_is_reported(self):
+        api = run_main(lambda run_state: run_state.set_render_cancelled())
+
+        assert api.render_finished.call_args.args[0] == "cancelled"
+
+    def test_a_keyboard_interrupt_is_reported(self):
+        """Ctrl-C never enters a terminal state in the state machine, so this
+        ending exists only in main()."""
+
+        def interrupt(run_state):
+            raise KeyboardInterrupt()
+
+        api = run_main(interrupt)
+
+        assert api.render_finished.call_args.args[0] == "failed"
+
+    def test_a_missing_api_key_reports_nothing(self):
+        """render() is never reached, so nothing identified the caller."""
+        api = run_main(api_key=None)
+
+        api.render_finished.assert_not_called()


### PR DESCRIPTION
## Purpose

Report the terminal state each render reached to the API, which cannot work it out on its own.

## Changes and design decisions

- New client call `render_finished(outcome, run_state)`, posting the outcome with the standard render state, which already carries the render id and the spec filename.
- Reported from `main()`'s `finally` — the one place that sees all five endings: success, failure, cancellation, an unexpected crash and a keyboard interrupt. The state machine's completed and failed hooks see only two of them, so reporting from there would under-count.
- Cancellation is tested before success, because a cancelled render leaves `render_succeeded` False and would otherwise be reported as a failure.
- Nothing is reported until the connection check has set a user email. That is exactly the condition "the API knows who we are", and it covers a missing key, an invalid key and an outdated client in one test.
- No retries, silent, with a five-second timeout. Nothing consumes the result, so the report must not add minutes to a render that has already ended, print retry noise over the exit summary, or hold the process open when the API stops answering. `post_request` gains an optional timeout, defaulting to the indefinite wait it does today.
- The API client moves from `render()` to `main()` so the `finally` can reach the same instance. The report goes last, behind the exit summary and the scratch cleanup, so nothing the user waits for sits behind a network call.
- The endpoint this calls ships with the matching API change. Until then the report fails and is swallowed, as any failed report is.

## Testing

`tests/test_render_finished_report.py` covers the outcome mapping (including cancellation winning over a recorded success), the reporting conditions, and that `main()` reports every ending — completed, failed, expected errors, cancelled and a keyboard interrupt — plus that a missing API key reports nothing and a failed report never propagates.
